### PR TITLE
[Codex] add devcontainer config

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,5 @@
+# Dev Container
+
+Use this container with VS Code Remote Containers to get a consistent development environment.
+
+It includes Node.js 18, Deno, the Supabase CLI, and Yarn. After building, dependencies install automatically.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+  "name": "Polymap Dev",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:18-bullseye",
+  "features": {
+    "ghcr.io/devcontainers/features/deno:1": {},
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "18",
+      "installYarn": true
+    },
+    "ghcr.io/devcontainers-contrib/features/supabase-cli:latest": {}
+  },
+  "postCreateCommand": "yarn install --immutable",
+  "customizations": {
+    "vscode": {
+      "extensions": ["denoland.vscode-deno"]
+    }
+  },
+  "remoteUser": "node"
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -5,6 +5,7 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",


### PR DESCRIPTION
## Summary
- add VS Code devcontainer with Node 18, Deno and Supabase CLI
- document container usage
- enable `noUncheckedIndexedAccess` in TS config

## Test Plan
- `yarn lint --fix` *(fails: couldn't find script)*
- `yarn typecheck` *(fails: couldn't find script)*
- `yarn test` *(fails: couldn't find script)*
- `yarn e2e:ci` *(fails: couldn't find script)*
- `yarn build` *(fails: couldn't find script)*

------
https://chatgpt.com/codex/tasks/task_e_685402d4646483269c5f0ef1f924c9b0

## Summary by Sourcery

Add and document a VS Code devcontainer setup for consistent development environment and tighten TypeScript configuration

Enhancements:
- Add VS Code devcontainer configuration with Node.js 18, Deno, Supabase CLI, and Yarn
- Enable noUncheckedIndexedAccess in apps/web tsconfig.json to enforce stricter type checks

Documentation:
- Add README.md in .devcontainer to document container usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a README file describing the development container setup and included tools.
- **Chores**
  - Introduced a development container configuration for a consistent development environment with Node.js, Deno, Supabase CLI, and Yarn.
- **Refactor**
  - Updated TypeScript settings for the web app to enforce stricter type checking on indexed accesses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->