### PR TITLE
[Codex] Add custom 404 page

### DIFF
--- a/apps/web/src/app/__tests__/not-found.test.tsx
+++ b/apps/web/src/app/__tests__/not-found.test.tsx
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react';
+import NotFound from '../not-found';
+
+test('links back to home', () => {
+  render(<NotFound />);
+  expect(screen.getByRole('link', { name: /return home/i })).toBeInTheDocument();
+});

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import Link from 'next/link';
+
+/** Renders a 404 Not Found page with a link back home. */
+export function NotFound() {
+  return (
+    <div className="min-h-screen grid place-content-center text-center p-8">
+      <h2 className="text-2xl font-bold mb-4">Page not found 🕵️‍♂️</h2>
+      <Link className="text-blue-600 underline" href="/">
+        Return home
+      </Link>
+    </div>
+  );
+}
+
+export default NotFound;


### PR DESCRIPTION
## Summary
- provide a `not-found` route for Next.js
- cover 404 page with a unit test

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68547d562cf88326ba6e327348a1cd5a

## Summary by Sourcery

Add a custom 404 page route in the Next.js app with a link back to home and include a unit test to verify its rendering.

New Features:
- Introduce a NotFound component at app/not-found.tsx to handle 404 pages.

Tests:
- Add a unit test for the NotFound page in __tests__/not-found.test.tsx to ensure correct rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a "Not Found" (404) page with a clear message and a link to return to the home page.

- **Tests**
  - Added a test to ensure the "Not Found" page includes a link back to the home page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->