### PR TITLE
[Codex] add global error page

### DIFF
--- a/apps/web/src/app/__tests__/error.test.tsx
+++ b/apps/web/src/app/__tests__/error.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import GlobalError from '../error';
+
+it('allows retry', async () => {
+  const reset = vi.fn();
+  render(<GlobalError error={new Error('fail')} reset={reset} />);
+  await userEvent.click(screen.getByRole('button', { name: /try again/i }));
+  expect(reset).toHaveBeenCalled();
+});

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import Link from 'next/link';
+
+export interface ErrorPageProps {
+  /** Error thrown during rendering. */
+  error: Error;
+  /** Resets the error boundary. */
+  reset: () => void;
+}
+
+/** Global error boundary component. */
+export default function GlobalError({ error, reset }: ErrorPageProps) {
+  return (
+    <div className="min-h-screen grid place-content-center text-center p-8">
+      <h2 className="text-2xl font-bold mb-4">Something went wrong 😵‍💫</h2>
+      <p className="text-red-600 mb-4" role="alert">
+        {error.message}
+      </p>
+      <button className="text-blue-600 underline" onClick={reset}>
+        Try again
+      </button>
+      <Link className="text-blue-600 underline block mt-2" href="/">
+        Return home
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- handle runtime errors with a global error page
- test retry behaviour

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_685488c39f248326b826cccaa10b8c5c

## Summary by Sourcery

Introduce a global error boundary component to handle runtime errors by displaying a user-friendly error page with retry and home navigation, and add tests to verify the retry behavior.

New Features:
- Add a global error boundary component that shows an error message, retry button, and return home link.

Tests:
- Add tests to verify the retry behavior of the error boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a global error screen that displays error messages and provides a "Try again" button for retrying failed operations.
  - Added a link for users to easily return to the home page when an error occurs.

- **Tests**
  - Added a test to verify that the retry button on the error screen functions correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->