### PR TITLE
[Codex] Add Header component

### DIFF
--- a/apps/web/src/components/Header.stories.tsx
+++ b/apps/web/src/components/Header.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Header } from './Header';
+
+const meta: Meta<typeof Header> = {
+  component: Header,
+  title: 'Components/Header',
+};
+export default meta;
+
+type Story = StoryObj<typeof Header>;
+
+export const Default: Story = {
+  args: {
+    title: 'Polymap',
+  },
+};
+

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import Link from 'next/link';
+import type { FC } from 'react';
+
+/** Props for {@link Header}. */
+export interface HeaderProps {
+  /** Title shown in the header. */
+  title: string;
+}
+
+/**
+ * Renders the application header with a home link.
+ */
+export const Header: FC<HeaderProps> = ({ title }) => {
+  return (
+    <header className="bg-background px-4 py-2 text-foreground">
+      <Link className="text-xl font-bold no-underline" href="/">
+        {title}
+      </Link>
+    </header>
+  );
+};
+

--- a/apps/web/src/components/__tests__/Header.test.tsx
+++ b/apps/web/src/components/__tests__/Header.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import { Header } from '../Header';
+
+describe('Header', () => {
+  it('links home with title', () => {
+    render(<Header title="Polymap" />);
+    const link = screen.getByRole('link', { name: 'Polymap' });
+    expect(link).toHaveAttribute('href', '/');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add a simple Header component
- include Storybook entry
- cover Header with a unit test

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68553f5677f483269d8300c85a918afe

## Summary by Sourcery

Add a new Header component with a title prop and home link, complete with Storybook documentation and unit tests.

New Features:
- Introduce a Header component that renders the app title as a home link

Documentation:
- Add a Storybook story for the Header component

Tests:
- Add a unit test covering the Header component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new header component with a clickable title linking to the homepage.
- **Documentation**
  - Added Storybook stories to visually showcase and document the header component.
- **Tests**
  - Added tests to verify correct rendering and linking behaviour of the header component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->