### PR TITLE
[Codex] add demo component

### DIFF
--- a/apps/web/src/components/Demo.stories.tsx
+++ b/apps/web/src/components/Demo.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Demo } from './Demo';
+
+const meta: Meta<typeof Demo> = {
+  component: Demo,
+  title: 'Components/Demo'
+};
+export default meta;
+
+type Story = StoryObj<typeof Demo>;
+
+export const Default: Story = {
+  args: {
+    message: 'Hello, Polymap! \u{1F44B}'
+  }
+};

--- a/apps/web/src/components/Demo.tsx
+++ b/apps/web/src/components/Demo.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import type { FC } from 'react';
+
+/** Props for {@link Demo}. */
+export interface DemoProps {
+  /** Message displayed by the demo. */
+  message: string;
+}
+
+/**
+ * Simple component that renders a message.
+ */
+export const Demo: FC<DemoProps> = ({ message }) => {
+  return <p>{message}</p>;
+};

--- a/apps/web/src/components/__tests__/Demo.test.tsx
+++ b/apps/web/src/components/__tests__/Demo.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import { Demo } from '../Demo';
+
+describe('Demo', () => {
+  it('renders the provided message', () => {
+    render(<Demo message="test" />);
+    expect(screen.getByText('test')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add `Demo` component
- create story and test

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6855434a00688326975bb2529e511dae

## Summary by Sourcery

Introduce a new Demo component that displays a message, and add accompanying Storybook story and unit test.

New Features:
- Add Demo component to render a provided message prop.

Documentation:
- Add Storybook story for the Demo component.

Tests:
- Add initial unit test file for the Demo component.