### PR TITLE
[Codex] add HowItWorks component

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import { FeatureHighlights } from "../components/FeatureHighlights";
+import { HowItWorks } from "../components/HowItWorks";
 
 /** Landing page component. */
 
@@ -33,6 +34,26 @@ export default function Home() {
             { icon: '🗺️', text: 'Interactive maps' },
             { icon: '📡', text: 'Real-time updates' },
             { icon: '☁️', text: 'Cloud sync' },
+          ]}
+        />
+
+        <HowItWorks
+          steps={[
+            {
+              icon: '1️⃣',
+              title: 'Add connections',
+              description: 'Upload your nodes and links.',
+            },
+            {
+              icon: '2️⃣',
+              title: 'Explore',
+              description: 'Navigate the interactive graph.',
+            },
+            {
+              icon: '3️⃣',
+              title: 'Share',
+              description: 'Collaborate with your team.',
+            },
           ]}
         />
 

--- a/apps/web/src/components/HowItWorks.stories.tsx
+++ b/apps/web/src/components/HowItWorks.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { HowItWorks } from './HowItWorks';
+
+const meta: Meta<typeof HowItWorks> = {
+  component: HowItWorks,
+  title: 'Components/HowItWorks',
+};
+export default meta;
+
+type Story = StoryObj<typeof HowItWorks>;
+
+export const Default: Story = {
+  args: {
+    steps: [
+      {
+        icon: '💾',
+        title: 'Upload data',
+        description: 'Import your dataset in seconds.',
+      },
+      {
+        icon: '🗺️',
+        title: 'Visualize',
+        description: 'Explore relationships on an interactive map.',
+      },
+      {
+        icon: '🤝',
+        title: 'Collaborate',
+        description: 'Share insights with your team.',
+      },
+    ],
+  },
+};

--- a/apps/web/src/components/HowItWorks.tsx
+++ b/apps/web/src/components/HowItWorks.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import type { FC, ReactNode } from 'react';
+
+/**
+ * Step information for {@link HowItWorks}.
+ */
+export interface Step {
+  /** Icon representing the step. */
+  icon: ReactNode;
+  /** Title of the step. */
+  title: string;
+  /** Detailed explanation. */
+  description: string;
+}
+
+/** Props for {@link HowItWorks}. */
+export interface HowItWorksProps {
+  /** Steps describing the process. */
+  steps: Step[];
+}
+
+/**
+ * Explains how the application works using a simple list of steps.
+ */
+export const HowItWorks: FC<HowItWorksProps> = ({ steps }) => {
+  return (
+    <ol className="grid list-inside list-decimal gap-6">
+      {steps.map((step, index) => (
+        <li className="flex items-start gap-2" key={index}>
+          <span className="text-xl" aria-hidden>
+            {step.icon}
+          </span>
+          <div>
+            <div className="font-semibold">{step.title}</div>
+            <p className="text-sm">{step.description}</p>
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+};

--- a/apps/web/src/components/__tests__/HowItWorks.test.tsx
+++ b/apps/web/src/components/__tests__/HowItWorks.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+
+import { HowItWorks } from '../HowItWorks';
+
+const steps = [
+  { icon: '💾', title: 'Upload data', description: 'Import your dataset in seconds.' },
+  { icon: '🗺️', title: 'Visualize', description: 'Explore relationships on an interactive map.' },
+];
+
+describe('HowItWorks', () => {
+  it('shows step titles', () => {
+    render(<HowItWorks steps={steps} />);
+    expect(screen.getByText('Upload data')).toBeInTheDocument();
+    expect(screen.getByText('Visualize')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add HowItWorks component with steps list
- document component in Storybook
- test component rendering
- showcase on landing page

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_685561267d4c832687aea5f50092a0f8

## Summary by Sourcery

Introduce a new HowItWorks component to illustrate key user steps and integrate it into the homepage, with accompanying documentation and tests.

New Features:
- Add HowItWorks React component to display a list of process steps.
- Integrate HowItWorks component into the landing page.

Documentation:
- Add a Storybook story to document the HowItWorks component.

Tests:
- Add a unit test to verify that step titles render correctly in the HowItWorks component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a "How It Works" section on the landing page, displaying a step-by-step guide for users.
- **Documentation**
	- Added Storybook stories to showcase and demonstrate the new "How It Works" component.
- **Tests**
	- Added tests to ensure the "How It Works" component renders steps correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->