### PR TITLE
[Codex] Add footer component

### DIFF
--- a/apps/web/src/components/Footer.stories.tsx
+++ b/apps/web/src/components/Footer.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Footer } from './Footer';
+
+const meta: Meta<typeof Footer> = {
+  component: Footer,
+  title: 'Components/Footer',
+};
+export default meta;
+
+type Story = StoryObj<typeof Footer>;
+
+export const Default: Story = {
+  args: {
+    links: [
+      { href: '/privacy', label: 'Privacy' },
+      { href: '/terms', label: 'Terms' },
+    ],
+  },
+};

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import Link from 'next/link';
+import type { FC } from 'react';
+
+/** A single footer link with label and URL. */
+export interface FooterLink {
+  /** Link destination. */
+  href: string;
+  /** Link text. */
+  label: string;
+}
+
+/** Props for {@link Footer}. */
+export interface FooterProps {
+  /** Navigation links displayed in the footer. */
+  links: FooterLink[];
+}
+
+/**
+ * Renders the application footer with copyright and links.
+ */
+export const Footer: FC<FooterProps> = ({ links }) => {
+  const year = new Date().getFullYear();
+  return (
+    <footer className="flex flex-col items-center gap-2 text-sm text-gray-500">
+      <nav className="flex flex-wrap justify-center gap-4">
+        {links.map(link => (
+          <Link
+            key={link.href}
+            className="hover:underline hover:underline-offset-4"
+            href={link.href}
+          >
+            {link.label}
+          </Link>
+        ))}
+      </nav>
+      <span>© {year} Polymap</span>
+    </footer>
+  );
+};

--- a/apps/web/src/components/__tests__/Footer.test.tsx
+++ b/apps/web/src/components/__tests__/Footer.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+
+import { Footer } from '../Footer';
+
+const links = [{ href: '/about', label: 'About' }];
+
+describe('Footer', () => {
+  it('shows link and copyright', () => {
+    const year = new Date().getFullYear();
+    render(<Footer links={links} />);
+    const link = screen.getByRole('link', { name: 'About' });
+    expect(link).toHaveAttribute('href', '/about');
+    expect(screen.getByText(`© ${year} Polymap`)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add new `Footer` component
- document with Storybook and unit test

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6855c46ac48c8326846887f8a02f5b53

## Summary by Sourcery

Add a new Footer component with navigation links support, document it in Storybook, and cover it with unit tests.

New Features:
- Introduce a reusable Footer component that renders navigation links and dynamic copyright

Documentation:
- Add a Storybook story showcasing the Footer component

Tests:
- Add unit tests to verify Footer links and copyright display correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new Footer component that displays navigation links and copyright information.
- **Tests**
  - Added tests to ensure the Footer component renders links and copyright text correctly.
- **Documentation**
  - Added a Storybook story to showcase the Footer component with example links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->