### PR TITLE
[Codex] Add gradient theme with pride accent options

### DIFF
--- a/apps/web/src/app/__tests__/home.test.tsx
+++ b/apps/web/src/app/__tests__/home.test.tsx
@@ -4,5 +4,7 @@ import Home from '../page';
 
 it('shows demo link', () => {
   render(<Home />);
-  expect(screen.getByRole('link', { name: /try the demo/i })).toBeInTheDocument();
+  const link = screen.getByRole('link', { name: /try the demo/i });
+  expect(link).toBeInTheDocument();
+  expect(link).toHaveClass('accent');
 });

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -34,6 +34,7 @@
 }
 
 body {
+  background: var(--background-start);
   background-image: linear-gradient(
     to bottom,
     var(--background-start),

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,26 +1,76 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
+  --background-start: #ffffff;
+  --background-end: #f7f7f7;
+  --background: var(--background-start);
   --foreground: #171717;
+  --accent: linear-gradient(
+    90deg,
+    #e70000,
+    #ff8c00,
+    #ffef00,
+    #00811f,
+    #0044ff,
+    #760089
+  );
 }
 
 @theme inline {
-  --color-background: var(--background);
+  --color-background: var(--background-start);
   --color-foreground: var(--foreground);
+  --color-accent: var(--accent);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
+    --background-start: #0a0a0a;
+    --background-end: #181818;
+    --background: var(--background-start);
     --foreground: #ededed;
   }
 }
 
 body {
-  background: var(--background);
+  background-image: linear-gradient(
+    to bottom,
+    var(--background-start),
+    var(--background-end)
+  );
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+}
+
+.accent {
+  background-image: var(--accent);
+  color: #fff;
+}
+
+.accent-rainbow {
+  --accent: linear-gradient(
+    90deg,
+    #e70000,
+    #ff8c00,
+    #ffef00,
+    #00811f,
+    #0044ff,
+    #760089
+  );
+}
+
+.accent-trans {
+  --accent: linear-gradient(
+    90deg,
+    #5bcefa,
+    #f5a9b8,
+    #ffffff,
+    #f5a9b8,
+    #5bcefa
+  );
+}
+
+.accent-bi {
+  --accent: linear-gradient(90deg, #d60270, #9b4f96, #0038a8);
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -39,7 +39,7 @@ export default function Home() {
         ]}
       />
       <Link
-        className="rounded-full bg-foreground px-5 py-3 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc]"
+        className="accent rounded-full px-5 py-3 transition-colors hover:opacity-90"
         href="/demo"
       >
         Try the demo

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+    },
+  },
   css: { postcss: {} },
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- add gradient background variables and accent color classes
- style home button with accent gradient
- check accent class in home page test
- fix vitest path resolution for `@` alias

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6855dd24056c8326936bb2b9a7b3109f

## Summary by Sourcery

Add a gradient-based theme with configurable pride accent color classes, apply the new accent styling to the home page demo link, update tests to assert the accent class, and fix Vitest path resolution for the '@' alias.

New Features:
- Introduce gradient background variables and apply them to the page body
- Add reusable accent classes with rainbow, trans, and bi pride gradient options
- Restyle the home page demo link to use the new accent gradient

Enhancements:
- Update CSS variable naming for background start/end and consolidate background-image usage

CI:
- Configure Vitest to resolve the '@' alias to the source directory

Tests:
- Extend the home page test to verify the demo link has the 'accent' class

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated background to use a vertical gradient for both light and dark themes.
  - Introduced new accent gradient styles, including rainbow, transgender pride, and bisexual pride options.
  - Simplified the demo link styling with a new accent class and updated hover behaviour.

- **Tests**
  - Improved test coverage for the demo link by checking both its presence and its accent styling.

- **Chores**
  - Enhanced test configuration with a new module resolution alias for improved code organisation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->