### PR TITLE
[Codex] fix runtime AFRAME error

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,7 @@
     "next": "15.3.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-force-graph": "^1.47.7"
+    "react-force-graph-2d": "^1.27.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/apps/web/src/components/ForceGraph.tsx
+++ b/apps/web/src/components/ForceGraph.tsx
@@ -5,7 +5,7 @@ import type { NodeObject, LinkObject } from 'force-graph';
 import type { FC } from 'react';
 
 const ForceGraph2D = dynamic(
-  () => import('react-force-graph').then(mod => mod.ForceGraph2D),
+  () => import('react-force-graph-2d').then(mod => mod.default),
   { ssr: false }
 );
 

--- a/apps/web/src/components/__tests__/Demo.test.tsx
+++ b/apps/web/src/components/__tests__/Demo.test.tsx
@@ -1,8 +1,5 @@
 import { render, screen } from '@testing-library/react';
 
-// Stub AFRAME used by react-force-graph in jsdom.
-(globalThis as { AFRAME?: Record<string, unknown> }).AFRAME = {};
-
 import { Demo } from '../Demo';
 
 describe('Demo', () => {

--- a/apps/web/src/components/__tests__/ForceGraph.test.tsx
+++ b/apps/web/src/components/__tests__/ForceGraph.test.tsx
@@ -1,5 +1,3 @@
-// Stub AFRAME before importing the graph to avoid runtime errors.
-(globalThis as { AFRAME?: Record<string, unknown> }).AFRAME = {};
 import { render } from '@testing-library/react';
 import { ForceGraph } from '../ForceGraph';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,44 +5,6 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"3d-force-graph-ar@npm:^1.9":
-  version: 1.9.5
-  resolution: "3d-force-graph-ar@npm:1.9.5"
-  dependencies:
-    aframe-forcegraph-component: "npm:3"
-    kapsule: "npm:^1.16"
-  checksum: 10c0/8a16adcb1adb88526be09df7113b0d7fcf84a03c38ea4617448df8efc1af901fb06f8ab0155c8a9febc4e55777892a8e18ca57b3a5ba06a32e6bb9269563113f
-  languageName: node
-  linkType: hard
-
-"3d-force-graph-vr@npm:^3.0":
-  version: 3.0.3
-  resolution: "3d-force-graph-vr@npm:3.0.3"
-  dependencies:
-    accessor-fn: "npm:1"
-    aframe-extras: "npm:^7.2"
-    aframe-forcegraph-component: "npm:3"
-    kapsule: "npm:^1.16"
-    polished: "npm:4"
-  peerDependencies:
-    aframe: ^1.5
-  checksum: 10c0/c02c469c5f641bb1b363364b8485d659932e2489c72337d4a2f568ba700146609fe24fd208284da967e9fbc1f931461d294fcf62a0e49d8b022a8a6e42ec8dbc
-  languageName: node
-  linkType: hard
-
-"3d-force-graph@npm:^1.76":
-  version: 1.77.0
-  resolution: "3d-force-graph@npm:1.77.0"
-  dependencies:
-    accessor-fn: "npm:1"
-    kapsule: "npm:^1.16"
-    three: "npm:>=0.118 <1"
-    three-forcegraph: "npm:1"
-    three-render-objects: "npm:^1.35"
-  checksum: 10c0/3352e7cb2fa52e4d9edb72aa094769da05eeea00e828bccde5fbf55c222843c1e6bd90c4edbc34ccca1d781547a40ac606225fd53fcd2c63cf51719fa5a06db9
-  languageName: node
-  linkType: hard
-
 "@adobe/css-tools@npm:^4.4.0":
   version: 4.4.3
   resolution: "@adobe/css-tools@npm:4.4.3"
@@ -241,7 +203,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.17.8":
+"@babel/runtime@npm:^7.12.5":
   version: 7.27.6
   resolution: "@babel/runtime@npm:7.27.6"
   checksum: 10c0/89726be83f356f511dcdb74d3ea4d873a5f0cf0017d4530cb53aa27380c01ca102d573eff8b8b77815e624b1f8c24e7f0311834ad4fb632c90a770fda00bd4c8
@@ -2033,28 +1995,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aframe-extras@npm:^7.2":
-  version: 7.5.4
-  resolution: "aframe-extras@npm:7.5.4"
-  dependencies:
-    nipplejs: "npm:^0.10.2"
-    three: "npm:^0.164.0"
-    three-pathfinding: "npm:^1.3.0"
-  checksum: 10c0/6efe0050157d59fabc8e80d8b2619edd2b128942c2a38ac153ba777e4986638a67df247904a54da1ab04c997ef66e28f00ee2bce12cd7bdc134ea7db13b28b48
-  languageName: node
-  linkType: hard
-
-"aframe-forcegraph-component@npm:3":
-  version: 3.2.3
-  resolution: "aframe-forcegraph-component@npm:3.2.3"
-  dependencies:
-    three-forcegraph: "npm:1"
-  peerDependencies:
-    aframe: "*"
-  checksum: 10c0/c2406f44df0bf5e91cde7af50fe4ce783716ba15d0194f04de4a980e3e9d9ebdcf63a726e9d3ffc73168f8bacf1a03dda32ea87737714498c34a9b07a067984d
-  languageName: node
-  linkType: hard
-
 "agent-base@npm:^7.1.0, agent-base@npm:^7.1.2":
   version: 7.1.3
   resolution: "agent-base@npm:7.1.3"
@@ -2822,15 +2762,6 @@ __metadata:
   version: 1.0.8
   resolution: "damerau-levenshtein@npm:1.0.8"
   checksum: 10c0/4c2647e0f42acaee7d068756c1d396e296c3556f9c8314bac1ac63ffb236217ef0e7e58602b18bb2173deec7ec8e0cac8e27cccf8f5526666b4ff11a13ad54a3
-  languageName: node
-  linkType: hard
-
-"data-bind-mapper@npm:1":
-  version: 1.0.3
-  resolution: "data-bind-mapper@npm:1.0.3"
-  dependencies:
-    accessor-fn: "npm:1"
-  checksum: 10c0/242fa247dd3d340694558020b05e6c0d5273b290f3a4f1eae35ac7d4946500df185fa2d72934f0b7a64a81352bfbf85ca3fe1c67cac1709571c3eba373002c38
   languageName: node
   linkType: hard
 
@@ -5262,54 +5193,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ngraph.events@npm:^1.0.0, ngraph.events@npm:^1.2.1":
-  version: 1.2.2
-  resolution: "ngraph.events@npm:1.2.2"
-  checksum: 10c0/98942bb9052ab634c304f7c29b2bb29fe61f672bc131639a2b3b9611b16e810ee7ff883b2b97a6e1ad0c190b8791e116455c66a515100ad0e593547e28d8026b
-  languageName: node
-  linkType: hard
-
-"ngraph.forcelayout@npm:3":
-  version: 3.3.1
-  resolution: "ngraph.forcelayout@npm:3.3.1"
-  dependencies:
-    ngraph.events: "npm:^1.0.0"
-    ngraph.merge: "npm:^1.0.0"
-    ngraph.random: "npm:^1.0.0"
-  checksum: 10c0/6d1756a132a55c7591966a45c53569e529d721a4a2eb11a37db3905e087091c933cde6fcfb1acfe5c98999566ee042f5dd6c8d612bd7488b0a60e079c51e5284
-  languageName: node
-  linkType: hard
-
-"ngraph.graph@npm:20":
-  version: 20.0.1
-  resolution: "ngraph.graph@npm:20.0.1"
-  dependencies:
-    ngraph.events: "npm:^1.2.1"
-  checksum: 10c0/a8c8d9505b776b5437696d13c1fabebfa0c9d88e93ca9801d08aaf50cf44bf8be22dfb410d950a68d86071da65c887e508ae07708ed035ab2b47cf62eabc4ded
-  languageName: node
-  linkType: hard
-
-"ngraph.merge@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "ngraph.merge@npm:1.0.0"
-  checksum: 10c0/30ded37341c597e0f3fd808f139149a42060a6a0f091a2878952389d52c4331049fd61eeba7dc77fcc14aea72a984dee682babb3b097ebc4242fcca8c96d7476
-  languageName: node
-  linkType: hard
-
-"ngraph.random@npm:^1.0.0":
-  version: 1.2.0
-  resolution: "ngraph.random@npm:1.2.0"
-  checksum: 10c0/83fcb37a9ad3cfd072c1641242aa8cf3fdaf79076395d61b527cc041c7df530a4cf30ee21484aa3bb47d9e69d3523778b454a7a567174ef90e87869e55d7c63c
-  languageName: node
-  linkType: hard
-
-"nipplejs@npm:^0.10.2":
-  version: 0.10.2
-  resolution: "nipplejs@npm:0.10.2"
-  checksum: 10c0/7123558685ccdb8144c9ce04f78db56916f4579b94cb19f5b412535a69981d288252974592692dba6857bd0ad012431156fe1442becd70097df86152ea7fe9ac
-  languageName: node
-  linkType: hard
-
 "node-domexception@npm:^1.0.0":
   version: 1.0.0
   resolution: "node-domexception@npm:1.0.0"
@@ -5686,15 +5569,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"polished@npm:4":
-  version: 4.3.1
-  resolution: "polished@npm:4.3.1"
-  dependencies:
-    "@babel/runtime": "npm:^7.17.8"
-  checksum: 10c0/45480d4c7281a134281cef092f6ecc202a868475ff66a390fee6e9261386e16f3047b4de46a2f2e1cf7fb7aa8f52d30b4ed631a1e3bcd6f303ca31161d4f07fe
-  languageName: node
-  linkType: hard
-
 "polymap@workspace:.":
   version: 0.0.0-use.local
   resolution: "polymap@workspace:."
@@ -5855,19 +5729,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-force-graph@npm:^1.47.7":
-  version: 1.47.7
-  resolution: "react-force-graph@npm:1.47.7"
+"react-force-graph-2d@npm:^1.27.1":
+  version: 1.27.1
+  resolution: "react-force-graph-2d@npm:1.27.1"
   dependencies:
-    3d-force-graph: "npm:^1.76"
-    3d-force-graph-ar: "npm:^1.9"
-    3d-force-graph-vr: "npm:^3.0"
     force-graph: "npm:^1.49"
     prop-types: "npm:15"
     react-kapsule: "npm:^2.5"
   peerDependencies:
     react: "*"
-  checksum: 10c0/f56980cbafad756e229b52cf8bebecc7e3e9540a48854df82e3be69fda589f2c92a01f5d158147404dff8007d51304410cae25692f6545af8098819e4445ac0e
+  checksum: 10c0/4b085872e509e05475b7b758adc150bf00c15c205b8cd5cbca1864d616bdf946c9b377aec7761fb218dde75a3ba1dadb8cb63abb3c2ee831e5fc8eddefa2adbb
   languageName: node
   linkType: hard
 
@@ -6756,64 +6627,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"three-forcegraph@npm:1":
-  version: 1.42.13
-  resolution: "three-forcegraph@npm:1.42.13"
-  dependencies:
-    accessor-fn: "npm:1"
-    d3-array: "npm:1 - 3"
-    d3-force-3d: "npm:2 - 3"
-    d3-scale: "npm:1 - 4"
-    d3-scale-chromatic: "npm:1 - 3"
-    data-bind-mapper: "npm:1"
-    kapsule: "npm:^1.16"
-    ngraph.forcelayout: "npm:3"
-    ngraph.graph: "npm:20"
-    tinycolor2: "npm:1"
-  peerDependencies:
-    three: ">=0.118.3"
-  checksum: 10c0/fdaa5bbbf48547980af51e6ccc5c35871f45602b31b74049412a3b2baaaa189744c8c408dd9a263d284088af0b83dec9e59373ee123b05988f8f7005a495c9d1
-  languageName: node
-  linkType: hard
-
-"three-pathfinding@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "three-pathfinding@npm:1.3.0"
-  peerDependencies:
-    three: 0.x.x
-  checksum: 10c0/a925d70f3f735c06f7f8f2dd97610fa8b49be34ef1cd2eaf663a89d36af9a2980c5bcc827ea950bb975e2d9282735b8296cb6d2139359f880e6bba2a1eac02c4
-  languageName: node
-  linkType: hard
-
-"three-render-objects@npm:^1.35":
-  version: 1.40.2
-  resolution: "three-render-objects@npm:1.40.2"
-  dependencies:
-    "@tweenjs/tween.js": "npm:18 - 25"
-    accessor-fn: "npm:1"
-    float-tooltip: "npm:^1.7"
-    kapsule: "npm:^1.16"
-    polished: "npm:4"
-  peerDependencies:
-    three: ">=0.168"
-  checksum: 10c0/41fb865d72aed6d4d6fa6c8880c0e122115722aaadffeb1d9b1709ca72d3c79ebf6beb8c8cbbaf88b7b5be814e1303cf909e23c2265c26f0550d2a2b711928be
-  languageName: node
-  linkType: hard
-
-"three@npm:>=0.118 <1":
-  version: 0.177.0
-  resolution: "three@npm:0.177.0"
-  checksum: 10c0/3e2ac1b9908e0d4dcecaf67c3d3e1b0b021dbfc7c80c2780005cc4e50532fb95b4c7f21669931e93c7b934d5576eb2364e1b34271bbd0e9484d1d723f836907b
-  languageName: node
-  linkType: hard
-
-"three@npm:^0.164.0":
-  version: 0.164.1
-  resolution: "three@npm:0.164.1"
-  checksum: 10c0/f34dc945444fba814be542a907a2f6f2bed3189315604b8ef936d95513b2a4030807df63dcbb48b658bbe3d3e77a446cf2d164c1c08465578c23d4c278d76bb3
-  languageName: node
-  linkType: hard
-
 "tinybench@npm:^2.5.1":
   version: 2.9.0
   resolution: "tinybench@npm:2.9.0"
@@ -6821,7 +6634,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinycolor2@npm:1, tinycolor2@npm:^1.6.0":
+"tinycolor2@npm:^1.6.0":
   version: 1.6.0
   resolution: "tinycolor2@npm:1.6.0"
   checksum: 10c0/9aa79a36ba2c2a87cb221453465cabacd04b9e35f9694373e846fdc78b1c768110f81e581ea41440106c0f24d9a023891d0887e8075885e790ac40eb0e74a5c1
@@ -7304,7 +7117,7 @@ __metadata:
     next: "npm:15.3.4"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
-    react-force-graph: "npm:^1.47.7"
+    react-force-graph-2d: "npm:^1.27.1"
     tailwindcss: "npm:^4"
     typescript: "npm:^5"
     vite: "npm:^5"


### PR DESCRIPTION
## Summary
- use the 2D build of react-force-graph
- drop unneeded AFRAME test stubs
- update workspace dependencies

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6855f7e715cc832683ab7908b6303ca7

## Summary by Sourcery

Switch to the 2D build of the force-graph library to eliminate AFRAME runtime errors and clean up related test stubs.

Bug Fixes:
- Use react-force-graph-2d instead of react-force-graph to fix the AFRAME runtime error.

Enhancements:
- Update dynamic import in the ForceGraph component to load the default export from react-force-graph-2d.

Build:
- Update package.json and yarn.lock to replace react-force-graph with react-force-graph-2d and refresh dependencies.

Tests:
- Remove obsolete AFRAME-related test stubs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependency from a general graph rendering package to a 2D-specific version for improved compatibility.
- **Tests**
	- Removed unnecessary global stubs for `AFRAME` in test files, streamlining the test environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->