### PR TITLE
[Codex] prevent AFRAME runtime error

### DIFF
--- a/apps/web/src/components/ForceGraph.tsx
+++ b/apps/web/src/components/ForceGraph.tsx
@@ -4,6 +4,23 @@ import dynamic from 'next/dynamic';
 import type { NodeObject, LinkObject } from 'force-graph';
 import type { FC } from 'react';
 
+interface AFrameStub {
+  components: Record<string, unknown>;
+  registerComponent: () => void;
+  utils: { diff: () => Record<string, never> };
+}
+
+// Stub AFRAME so optional AR modules don't throw in the browser.
+const globalObj = globalThis as { AFRAME?: AFrameStub };
+if (typeof globalObj !== 'undefined' && !globalObj.AFRAME) {
+  globalObj.AFRAME = {
+    components: {},
+    registerComponent: () => {},
+    utils: { diff: () => ({}) },
+  };
+}
+
+
 const ForceGraph2D = dynamic(
   () => import('react-force-graph').then(mod => mod.ForceGraph2D),
   { ssr: false }


### PR DESCRIPTION
## Summary
- stub `AFRAME` in ForceGraph to avoid runtime crash

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn test --run vitest/__snapshots__`
- `yarn e2e:ci`


------
https://chatgpt.com/codex/tasks/task_e_6855f7e715cc832683ab7908b6303ca7