### PR TITLE
[Codex] Add architecture and style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,6 @@ yarn test
 yarn e2e:ci
 yarn build
 ```
+
+See [docs/architecture.md](docs/architecture.md) for an overview of the monorepo and [docs/styleguide.md](docs/styleguide.md) for coding standards.
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,20 @@
+# Architecture Overview
+
+This repository is a Yarn workspaces monorepo. The root `package.json` manages common dependencies and scripts for all workspaces.
+
+## Directory Structure
+
+- `apps/` – application source code. Currently contains `web`, a Next.js 15 project.
+- `scripts/` – reusable Node.js utilities.
+- `supabase/` – configuration for local Supabase development.
+
+Each workspace defines its own `package.json` with scripts for development, linting, type checking, testing and building.
+
+### Web App
+
+The `apps/web` workspace is a Next.js 15 application written in TypeScript. It uses Tailwind CSS for styling and Vitest for unit tests. Playwright powers the end‑to‑end tests. React components follow a functional style with named exports.
+
+### Supabase
+
+The `supabase` folder contains settings for running a local Supabase stack. Environment files and migrations are excluded from version control and must not be accessed by automated agents.
+

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -1,0 +1,29 @@
+# Polymap Style Guide
+
+This guide summarises the UI and code standards used across the monorepo.
+
+## Code
+
+- Use TypeScript with `strict` and `noUncheckedIndexedAccess` enabled.
+- Prefer functional React components and hooks. Avoid `class` components.
+- Export all components and utilities by name—no default exports.
+- Run `yarn lint --fix` before committing. ESLint and Prettier enforce formatting rules.
+- Tailwind classes must be sorted with the `@tailwindcss/typography` plugin.
+- Keep scripts under `scripts/` small and provide a `--help` flag with `yargs`.
+
+## UI
+
+- Style components with Tailwind CSS. Keep the generated bundle under 200 KB gzipped.
+- Provide a Storybook story for each new component.
+- Use `react-force-graph` for network visualisations. Do not bundle `three` directly.
+- Aim for a Lighthouse performance score above 90 in CI (`yarn lhci autorun`).
+
+## Testing
+
+- Unit tests run with Vitest and jsdom.
+- Snapshot tests reside in `vitest/__snapshots__` and run via `yarn test --run vitest/__snapshots__`.
+- End-to-end tests run with Playwright (`yarn e2e:ci`).
+
+## Documentation
+
+Store documentation in `/docs` and keep this style guide referenced from the root `AGENTS.md` file.


### PR DESCRIPTION
## Summary
- document repository layout in `/docs/architecture.md`
- outline development standards in `/docs/styleguide.md`
- link docs from the root README

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6856e53b23e083269da4565f2baad5e7

## Summary by Sourcery

Add architecture and style guide documentation and link them in the root README.

Documentation:
- Document the monorepo structure and workspace details in docs/architecture.md.
- Define development standards and UI/code guidelines in docs/styleguide.md.
- Link the new documentation from the root README for easy access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README with additional references to architecture and style guide documents.
  - Added a new architecture overview document detailing the monorepo structure and workspace setup.
  - Introduced a comprehensive style guide covering coding, UI, testing, and documentation standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->