### PR TITLE
[Codex] add e2e home page check

### DIFF
--- a/apps/web/e2e/sample.spec.ts
+++ b/apps/web/e2e/sample.spec.ts
@@ -1,5 +1,14 @@
 import { test, expect } from '@playwright/test';
 
-test('dummy', async ({ page }) => {
-  expect(true).toBe(true);
+// Ensure the home page renders expected content
+// Launches the local site and checks for heading and demo link
+
+test('shows hero section', async ({ page }) => {
+  await page.goto('/');
+  await expect(
+    page.getByRole('heading', {
+      name: /visualise your polycule\. share with ease/i
+    })
+  ).toBeVisible();
+  await expect(page.getByRole('link', { name: /try the demo/i })).toBeVisible();
 });

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,5 +1,13 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  testDir: 'e2e'
+  testDir: 'e2e',
+  webServer: {
+    command: 'yarn build && yarn start -p 3000',
+    port: 3000,
+    reuseExistingServer: !process.env.CI
+  },
+  use: {
+    baseURL: 'http://localhost:3000'
+  }
 });


### PR DESCRIPTION
## Summary
- load `/` in Playwright and verify hero text and demo link
- serve Next.js via Playwright's webServer for CI

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn test --run vitest/__snapshots__`
- `yarn e2e:ci`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6856f58a8b0c832692cafcf928369270

## Summary by Sourcery

Add an end-to-end test for the home page and configure Playwright to build and serve the Next.js app for CI

New Features:
- Introduce an E2E test that loads the home page and verifies the hero text and demo link

Enhancements:
- Configure Playwright’s webServer to build and start the Next.js application on port 3000 with reuseExistingServer support
- Set the baseURL for Playwright tests to http://localhost:3000

CI:
- Enable webServer configuration to run the Next.js server during CI e2e runs

Tests:
- Add a Playwright spec in e2e/sample.spec.ts for home page validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Improved end-to-end tests to verify visibility of key UI elements on the home page, including headings and demo links.
	- Updated test configuration to automatically build and start the web server before running tests, ensuring tests run against a live environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->