### PR TITLE
[Codex] Resize demo force graph

### DIFF
--- a/apps/web/src/components/ForceGraph.tsx
+++ b/apps/web/src/components/ForceGraph.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from 'next/dynamic';
 import type { NodeObject, LinkObject } from 'force-graph';
-import type { FC } from 'react';
+import { type FC, useEffect, useRef, useState } from 'react';
 
 const ForceGraph2D = dynamic(
   () => import('react-force-graph-2d').then(mod => mod.default),
@@ -18,5 +18,32 @@ export interface ForceGraphProps {
  * Renders an interactive force-directed graph.
  */
 export const ForceGraph: FC<ForceGraphProps> = ({ data }) => {
-  return <ForceGraph2D graphData={data} />;
+  const ref = useRef<HTMLDivElement>(null);
+  const [size, setSize] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) {
+      return;
+    }
+    const update = () => {
+      setSize({ width: el.clientWidth, height: el.clientHeight });
+    };
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div ref={ref} className="h-full w-full">
+      {size.width > 0 && size.height > 0 && (
+        <ForceGraph2D
+          graphData={data}
+          width={size.width}
+          height={size.height}
+        />
+      )}
+    </div>
+  );
 };

--- a/apps/web/src/components/__tests__/ForceGraph.test.tsx
+++ b/apps/web/src/components/__tests__/ForceGraph.test.tsx
@@ -1,4 +1,9 @@
 import { render } from '@testing-library/react';
+import { vi } from 'vitest';
+
+const mockFG = vi.fn(() => <div data-testid="fg" />);
+vi.mock('react-force-graph-2d', () => ({ default: mockFG }));
+
 import { ForceGraph } from '../ForceGraph';
 
 describe('ForceGraph', () => {
@@ -6,5 +11,14 @@ describe('ForceGraph', () => {
     expect(() =>
       render(<ForceGraph data={{ nodes: [], links: [] }} />)
     ).not.toThrow();
+  });
+
+  it('provides a full-size wrapper', () => {
+    const { container } = render(
+      <div style={{ width: '320px', height: '180px' }}>
+        <ForceGraph data={{ nodes: [], links: [] }} />
+      </div>
+    );
+    expect(container.querySelector('.h-full.w-full')).toBeInTheDocument();
   });
 });

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -1,1 +1,24 @@
 import '@testing-library/jest-dom';
+
+// Minimal ResizeObserver stub for jsdom
+class ResizeObserver {
+  private readonly cb: ResizeObserverCallback;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  constructor(cb: ResizeObserverCallback) {
+    this.cb = cb;
+  }
+  observe(): void {
+    this.cb(
+      [
+        {
+          contentRect: { width: 320, height: 180 },
+        } as unknown as ResizeObserverEntry,
+      ],
+      this
+    );
+  }
+  unobserve(): void {}
+  disconnect(): void {}
+}
+(globalThis as any).ResizeObserver = ResizeObserver;
+

--- a/apps/web/vitest/__snapshots__/__snapshots__/Demo.snapshot.test.tsx.snap
+++ b/apps/web/vitest/__snapshots__/__snapshots__/Demo.snapshot.test.tsx.snap
@@ -10,6 +10,10 @@ exports[`Demo snapshot > matches 1`] = `
   </p>
   <div
     class="h-64"
-  />
+  >
+    <div
+      class="h-full w-full"
+    />
+  </div>
 </div>
 `;


### PR DESCRIPTION
## Summary
- make ForceGraph responsive using ResizeObserver
- stub ResizeObserver in tests
- verify wrapper div in ForceGraph tests
- update demo snapshot

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6873e008e7e483268c36224520954e76

## Summary by Sourcery

Make the ForceGraph component responsive by observing its container size, update tests to support ResizeObserver, and refresh the demo snapshot

New Features:
- Add responsive resizing to ForceGraph component using ResizeObserver

Enhancements:
- Defer rendering of the ForceGraph2D canvas until container dimensions are measured

Tests:
- Stub ResizeObserver in test setup
- Add test verifying full-size wrapper div for ForceGraph
- Regenerate demo snapshot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The force graph visualisation now automatically adjusts its size to fit its container, providing a more responsive experience.

* **Tests**
  * Improved test coverage for the force graph component, including checks for correct rendering within containers of varying sizes.
  * Enhanced testing reliability by introducing a stub for ResizeObserver in the test environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->