### PR TITLE
[Codex] add node labels to demo graph

### DIFF
--- a/apps/web/src/components/Demo.tsx
+++ b/apps/web/src/components/Demo.tsx
@@ -1,18 +1,18 @@
 'use client';
 
 import type { FC } from 'react';
-import type { LinkObject, NodeObject } from 'force-graph';
-import { ForceGraph } from './ForceGraph';
+import type { LinkObject } from 'force-graph';
+import { ForceGraph, type ForceGraphNode } from './ForceGraph';
 
-const demoData: { nodes: NodeObject[]; links: LinkObject[] } = {
+const demoData: { nodes: ForceGraphNode[]; links: LinkObject[] } = {
   nodes: [
-    { id: 'You' },
-    { id: 'Partner' },
-    { id: 'Friend' },
+    { id: 'you', name: 'You' },
+    { id: 'partner', name: 'Partner' },
+    { id: 'friend', name: 'Friend' },
   ],
   links: [
-    { source: 'You', target: 'Partner' },
-    { source: 'You', target: 'Friend' },
+    { source: 'you', target: 'partner' },
+    { source: 'you', target: 'friend' },
   ],
 } as const;
 

--- a/apps/web/src/components/ForceGraph.tsx
+++ b/apps/web/src/components/ForceGraph.tsx
@@ -10,8 +10,13 @@ const ForceGraph2D = dynamic(
 );
 
 /** Props for {@link ForceGraph}. */
+export interface ForceGraphNode extends NodeObject {
+  /** Optional display name for the node. */
+  name?: string;
+}
+
 export interface ForceGraphProps {
-  data: { nodes: NodeObject[]; links: LinkObject[] };
+  data: { nodes: ForceGraphNode[]; links: LinkObject[] };
 }
 
 /**
@@ -40,6 +45,17 @@ export const ForceGraph: FC<ForceGraphProps> = ({ data }) => {
       {size.width > 0 && size.height > 0 && (
         <ForceGraph2D
           graphData={data}
+          nodeLabel={node => (node as ForceGraphNode).name ?? String(node.id)}
+          nodeCanvasObject={(node, ctx, scale) => {
+            const n = node as ForceGraphNode;
+            const label = n.name ?? String(n.id);
+            const fontSize = 12 / scale;
+            ctx.font = `${fontSize}px sans-serif`;
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'middle';
+            ctx.fillStyle = '#000';
+            ctx.fillText(label, node.x ?? 0, node.y ?? 0);
+          }}
           width={size.width}
           height={size.height}
         />


### PR DESCRIPTION
## Summary
- display node names within ForceGraph
- populate demo graph with named nodes

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn test --run vitest/__snapshots__`
- `yarn e2e:ci`


------
https://chatgpt.com/codex/tasks/task_e_6873e9f938f483269d94b9931b7a3f95

## Summary by Sourcery

Add optional node labels to the force graph and update the demo data to use named nodes

New Features:
- Introduce ForceGraphNode type with an optional name property
- Render node labels on the graph canvas using nodeCanvasObject and nodeLabel props
- Populate the demo graph with nodes that include name fields and adjust link sources accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Node labels are now displayed in the force graph visualisation, showing either the node's name or ID.
  * Improved visual clarity by customising how node labels appear on the graph.

* **Style**
  * Updated node identifiers and added names for better consistency and readability in the demo data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->