### PR TITLE
[Codex] add node val to demo component

### DIFF
--- a/apps/web/src/components/Demo.tsx
+++ b/apps/web/src/components/Demo.tsx
@@ -6,9 +6,9 @@ import { ForceGraph, type ForceGraphNode } from './ForceGraph';
 
 const demoData: { nodes: ForceGraphNode[]; links: LinkObject[] } = {
   nodes: [
-    { id: 'you', name: 'You' },
-    { id: 'partner', name: 'Partner' },
-    { id: 'friend', name: 'Friend' },
+    { id: 'you', name: 'You', val: 2 },
+    { id: 'partner', name: 'Partner', val: 1 },
+    { id: 'friend', name: 'Friend', val: 1 },
   ],
   links: [
     { source: 'you', target: 'partner' },
@@ -24,6 +24,8 @@ export interface DemoProps {
 
 /**
  * Renders a small force-directed graph with an optional heading.
+ *
+ * Nodes include a `val` attribute that controls their display size.
  */
 export const Demo: FC<DemoProps> = ({ message = 'Example polycule' }) => {
   return (

--- a/apps/web/src/components/ForceGraph.tsx
+++ b/apps/web/src/components/ForceGraph.tsx
@@ -13,6 +13,8 @@ const ForceGraph2D = dynamic(
 export interface ForceGraphNode extends NodeObject {
   /** Optional display name for the node. */
   name?: string;
+  /** Optional numeric value used for node sizing. */
+  val?: number;
 }
 
 export interface ForceGraphProps {

--- a/apps/web/src/components/__tests__/Demo.test.tsx
+++ b/apps/web/src/components/__tests__/Demo.test.tsx
@@ -1,10 +1,28 @@
 import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
 
+vi.mock('../ForceGraph', () => ({
+  ForceGraph: vi.fn(() => <div data-testid="fg" />),
+}));
+
+import { ForceGraph } from '../ForceGraph';
 import { Demo } from '../Demo';
+
+const mockFG = vi.mocked(ForceGraph);
 
 describe('Demo', () => {
   it('shows message', () => {
     expect(() => render(<Demo message="Test" />)).not.toThrow();
     expect(screen.getByText('Test 😊')).toBeInTheDocument();
+  });
+
+  it('passes node values to ForceGraph', () => {
+    render(<Demo />);
+    expect(mockFG).toHaveBeenCalled();
+    const firstCall = mockFG.mock.calls[0] as unknown[];
+    const { nodes } = (firstCall[0] as { data: { nodes: { val?: number }[] } }).data;
+    for (const node of nodes) {
+      expect(node.val).toBeDefined();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- size demo nodes with `val`
- document optional node value
- verify ForceGraph receives node values

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6873f484404c8326996397744bab85ea