### PR TITLE
[Codex] support nodeAutoColorBy in ForceGraph

### DIFF
--- a/apps/web/src/components/ForceGraph.stories.tsx
+++ b/apps/web/src/components/ForceGraph.stories.tsx
@@ -15,5 +15,6 @@ export const Default: Story = {
       nodes: [{ id: '1' }, { id: '2' }],
       links: [{ source: '1', target: '2' }],
     },
+    nodeAutoColorBy: 'id',
   },
 };

--- a/apps/web/src/components/ForceGraph.tsx
+++ b/apps/web/src/components/ForceGraph.tsx
@@ -24,12 +24,18 @@ export interface ForceGraphLink extends LinkObject {
 
 export interface ForceGraphProps {
   data: { nodes: ForceGraphNode[]; links: ForceGraphLink[] };
+  /**
+   * Auto-assign node colors by this field.
+   *
+   * Accepts a key string or accessor function.
+   */
+  nodeAutoColorBy?: string | ((node: ForceGraphNode) => string | null) | null;
 }
 
 /**
  * Renders an interactive force-directed graph.
  */
-export const ForceGraph: FC<ForceGraphProps> = ({ data }) => {
+export const ForceGraph: FC<ForceGraphProps> = ({ data, nodeAutoColorBy }) => {
   const ref = useRef<HTMLDivElement>(null);
   const [size, setSize] = useState({ width: 0, height: 0 });
 
@@ -54,6 +60,7 @@ export const ForceGraph: FC<ForceGraphProps> = ({ data }) => {
           graphData={data}
           width={size.width}
           height={size.height}
+          nodeAutoColorBy={nodeAutoColorBy}
         />
       )}
     </div>

--- a/apps/web/src/components/__tests__/ForceGraph.test.tsx
+++ b/apps/web/src/components/__tests__/ForceGraph.test.tsx
@@ -21,4 +21,12 @@ describe('ForceGraph', () => {
     );
     expect(container.querySelector('.h-full.w-full')).toBeInTheDocument();
   });
+
+  it('accepts nodeAutoColorBy prop', () => {
+    expect(() =>
+      render(
+        <ForceGraph data={{ nodes: [], links: [] }} nodeAutoColorBy="group" />
+      )
+    ).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
- expose optional `nodeAutoColorBy` prop for the ForceGraph wrapper
- document and test the new prop
- update storybook story to demonstrate automatic node colouring

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_687408b13f4c8326b6430c4a7a0e2513

## Summary by Sourcery

Expose a new nodeAutoColorBy prop in the ForceGraph component to enable automatic node color assignment based on a key or accessor, and add corresponding tests and Storybook documentation.

New Features:
- Add optional nodeAutoColorBy prop to ForceGraph for automatic node coloring.

Documentation:
- Update Storybook story to demonstrate automatic node coloring via nodeAutoColorBy.

Tests:
- Add unit test to ensure ForceGraph accepts nodeAutoColorBy prop without errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an option to automatically colour nodes in the ForceGraph based on a specified attribute.
* **Tests**
  * Added a test to ensure the ForceGraph component correctly handles the new node colouring option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->