### PR TITLE
[Codex] Add linkAutoColorBy

### DIFF
--- a/apps/web/src/components/Demo.tsx
+++ b/apps/web/src/components/Demo.tsx
@@ -31,7 +31,11 @@ export const Demo: FC<DemoProps> = ({ message = 'Example polycule' }) => {
     <div className="space-y-4 rounded border border-dashed border-gray-400 p-4 text-center">
       <p>{message} 😊</p>
       <div className="h-64">
-        <ForceGraph data={demoData} nodeAutoColorBy={"id"} />
+        <ForceGraph
+          data={demoData}
+          nodeAutoColorBy={"id"}
+          linkAutoColorBy="name"
+        />
       </div>
     </div>
   );

--- a/apps/web/src/components/ForceGraph.stories.tsx
+++ b/apps/web/src/components/ForceGraph.stories.tsx
@@ -16,5 +16,6 @@ export const Default: Story = {
       links: [{ source: '1', target: '2' }],
     },
     nodeAutoColorBy: 'id',
+    linkAutoColorBy: 'source',
   },
 };

--- a/apps/web/src/components/ForceGraph.tsx
+++ b/apps/web/src/components/ForceGraph.tsx
@@ -28,14 +28,24 @@ export interface ForceGraphProps {
    * Auto-assign node colors by this field.
    *
    * Accepts a key string or accessor function.
-   */
+  */
   nodeAutoColorBy?: string | ((node: ForceGraphNode) => string | null) | null;
+  /**
+   * Auto-assign link colors by this field.
+   *
+   * Accepts a key string or accessor function.
+   */
+  linkAutoColorBy?: string | ((link: ForceGraphLink) => string | null) | null;
 }
 
 /**
  * Renders an interactive force-directed graph.
  */
-export const ForceGraph: FC<ForceGraphProps> = ({ data, nodeAutoColorBy }) => {
+export const ForceGraph: FC<ForceGraphProps> = ({
+  data,
+  nodeAutoColorBy,
+  linkAutoColorBy,
+}) => {
   const ref = useRef<HTMLDivElement>(null);
   const [size, setSize] = useState({ width: 0, height: 0 });
 
@@ -61,6 +71,7 @@ export const ForceGraph: FC<ForceGraphProps> = ({ data, nodeAutoColorBy }) => {
           width={size.width}
           height={size.height}
           nodeAutoColorBy={nodeAutoColorBy}
+          linkAutoColorBy={linkAutoColorBy}
         />
       )}
     </div>

--- a/apps/web/src/components/__tests__/ForceGraph.test.tsx
+++ b/apps/web/src/components/__tests__/ForceGraph.test.tsx
@@ -29,4 +29,12 @@ describe('ForceGraph', () => {
       )
     ).not.toThrow();
   });
+
+  it('accepts linkAutoColorBy prop', () => {
+    expect(() =>
+      render(
+        <ForceGraph data={{ nodes: [], links: [] }} linkAutoColorBy="group" />
+      )
+    ).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
- add `linkAutoColorBy` prop to `ForceGraph`
- demo link colour in `Demo`
- update storybook and tests

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`


------
https://chatgpt.com/codex/tasks/task_e_687426ec84588326ba3ec9795c393c7f

## Summary by Sourcery

Add linkAutoColorBy support to the ForceGraph component, update demo and Storybook examples to use it, and add a corresponding prop acceptance test.

New Features:
- Introduce linkAutoColorBy prop to ForceGraph to auto-assign link colors based on a field
- Update Demo component and Storybook stories to showcase linkAutoColorBy

Tests:
- Add test to verify that ForceGraph accepts the linkAutoColorBy prop without error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automatic link colouring in the ForceGraph visualisation, allowing links to be coloured based on a specified attribute.
* **Tests**
  * Added a test to ensure the new link colouring feature works without errors.
* **Documentation**
  * Updated Storybook examples to showcase the new link colouring capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->