### PR TITLE
[Codex] Add Supabase client singleton

### DIFF
--- a/apps/web/src/utils/__tests__/supabase.test.ts
+++ b/apps/web/src/utils/__tests__/supabase.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { getSupabaseClient } from '../supabase'
+
+const ORIGINAL_ENV = process.env
+
+describe('getSupabaseClient', () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV, NEXT_PUBLIC_SUPABASE_URL: 'http://localhost', NEXT_PUBLIC_SUPABASE_ANON_KEY: 'anon' }
+  })
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV
+  })
+
+  it('returns the same instance on multiple calls', () => {
+    const first = getSupabaseClient()
+    const second = getSupabaseClient()
+    expect(first).toBe(second)
+  })
+})

--- a/apps/web/src/utils/supabase.ts
+++ b/apps/web/src/utils/supabase.ts
@@ -1,0 +1,22 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js'
+
+let client: SupabaseClient | undefined
+
+/**
+ * Returns a singleton Supabase client using environment configuration.
+ */
+export const getSupabaseClient = (): SupabaseClient => {
+  if (client) {
+    return client
+  }
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+  if (!url || !anonKey) {
+    throw new Error('Supabase environment variables are not set.')
+  }
+
+  client = createClient(url, anonKey)
+  return client
+}


### PR DESCRIPTION
## Summary
- create `getSupabaseClient` utility to initialize Supabase once
- verify singleton behaviour with a unit test

## Test Plan
- `yarn lint --fix`
- `yarn test`
- `yarn e2e:ci`
- `yarn typecheck`


------
https://chatgpt.com/codex/tasks/task_e_687695c7bf688326acea147dff2d3c84

## Summary by Sourcery

Add a singleton Supabase client utility for consistent initialization and reuse across the application.

New Features:
- Introduce getSupabaseClient to initialize and cache a Supabase client using environment variables, throwing an error if they are unset.

Tests:
- Add a Vitest unit test to verify that getSupabaseClient returns the same instance on multiple calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a utility to provide a singleton Supabase client across the application.

* **Tests**
  * Added tests to verify the singleton behaviour of the Supabase client utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->