### PR TITLE
[Codex] create auth ui components

### DIFF
--- a/apps/web/src/components/SignInForm.stories.tsx
+++ b/apps/web/src/components/SignInForm.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { SignInForm } from './SignInForm'
+
+const meta: Meta<typeof SignInForm> = {
+  component: SignInForm,
+  title: 'Components/SignInForm'
+}
+export default meta
+
+type Story = StoryObj<typeof SignInForm>
+
+export const Default: Story = {}

--- a/apps/web/src/components/SignInForm.tsx
+++ b/apps/web/src/components/SignInForm.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { type FormEvent, type FC, useState } from 'react'
+import { getSupabaseClient } from '@/utils/supabase'
+
+/** Props for {@link SignInForm}. */
+export interface SignInFormProps {
+  /** Called when sign in succeeds. */
+  onSuccess?: () => void
+}
+
+/**
+ * Collects email and password then signs the user in via Supabase.
+ */
+export const SignInForm: FC<SignInFormProps> = ({ onSuccess }) => {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setError(null)
+    const { error } = await getSupabaseClient().auth.signInWithPassword({
+      email,
+      password
+    })
+    if (error) {
+      setError(error.message)
+      return
+    }
+    onSuccess?.()
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="flex flex-col gap-2">
+        <label htmlFor="signin-email">Email</label>
+        <input
+          id="signin-email"
+          type="email"
+          className="rounded border px-2 py-1"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+          required
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        <label htmlFor="signin-password">Password</label>
+        <input
+          id="signin-password"
+          type="password"
+          className="rounded border px-2 py-1"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          required
+        />
+      </div>
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      <button type="submit" className="rounded bg-primary px-4 py-2 text-white">
+        Sign In
+      </button>
+    </form>
+  )
+}

--- a/apps/web/src/components/SignUpForm.stories.tsx
+++ b/apps/web/src/components/SignUpForm.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { SignUpForm } from './SignUpForm'
+
+const meta: Meta<typeof SignUpForm> = {
+  component: SignUpForm,
+  title: 'Components/SignUpForm'
+}
+export default meta
+
+type Story = StoryObj<typeof SignUpForm>
+
+export const Default: Story = {}

--- a/apps/web/src/components/SignUpForm.tsx
+++ b/apps/web/src/components/SignUpForm.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { type FormEvent, type FC, useState } from 'react'
+import { getSupabaseClient } from '@/utils/supabase'
+
+/** Props for {@link SignUpForm}. */
+export interface SignUpFormProps {
+  /** Called when sign up succeeds. */
+  onSuccess?: () => void
+}
+
+/**
+ * Collects email and password then registers the user via Supabase.
+ */
+export const SignUpForm: FC<SignUpFormProps> = ({ onSuccess }) => {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setError(null)
+    const { error } = await getSupabaseClient().auth.signUp({
+      email,
+      password
+    })
+    if (error) {
+      setError(error.message)
+      return
+    }
+    onSuccess?.()
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="flex flex-col gap-2">
+        <label htmlFor="signup-email">Email</label>
+        <input
+          id="signup-email"
+          type="email"
+          className="rounded border px-2 py-1"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+          required
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        <label htmlFor="signup-password">Password</label>
+        <input
+          id="signup-password"
+          type="password"
+          className="rounded border px-2 py-1"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          required
+        />
+      </div>
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      <button type="submit" className="rounded bg-primary px-4 py-2 text-white">
+        Sign Up
+      </button>
+    </form>
+  )
+}

--- a/apps/web/src/components/__tests__/SignInForm.test.tsx
+++ b/apps/web/src/components/__tests__/SignInForm.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi } from 'vitest'
+
+const signIn = vi.fn(async () => ({ error: null }))
+vi.mock('../../utils/supabase', () => ({
+  getSupabaseClient: () => ({ auth: { signInWithPassword: signIn } })
+}))
+
+import { SignInForm } from '../SignInForm'
+
+describe('SignInForm', () => {
+  it('calls signInWithPassword with provided credentials', async () => {
+    render(<SignInForm />)
+    await userEvent.type(screen.getByLabelText(/email/i), 'a@b.com')
+    await userEvent.type(screen.getByLabelText(/password/i), 'secret')
+    await userEvent.click(screen.getByRole('button', { name: /sign in/i }))
+    expect(signIn).toHaveBeenCalledWith({ email: 'a@b.com', password: 'secret' })
+  })
+})

--- a/apps/web/src/components/__tests__/SignUpForm.test.tsx
+++ b/apps/web/src/components/__tests__/SignUpForm.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi } from 'vitest'
+
+const signUp = vi.fn(async () => ({ data: null, error: null }))
+vi.mock('../../utils/supabase', () => ({
+  getSupabaseClient: () => ({ auth: { signUp } })
+}))
+
+import { SignUpForm } from '../SignUpForm'
+
+describe('SignUpForm', () => {
+  it('calls signUp with provided credentials', async () => {
+    render(<SignUpForm />)
+    await userEvent.type(screen.getByLabelText(/email/i), 'c@d.com')
+    await userEvent.type(screen.getByLabelText(/password/i), 'secret')
+    await userEvent.click(screen.getByRole('button', { name: /sign up/i }))
+    expect(signUp).toHaveBeenCalledWith({ email: 'c@d.com', password: 'secret' })
+  })
+})


### PR DESCRIPTION
## Summary
- add SignInForm and SignUpForm components with Supabase integration
- generate stories for both forms
- test authentication form behaviour

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6877cfa80eec83268ff67e22006151e2

## Summary by Sourcery

Introduce SignInForm and SignUpForm React components with Supabase authentication, accompanied by Storybook stories and unit tests

New Features:
- Add SignInForm component for user login via Supabase
- Add SignUpForm component for user registration via Supabase

Enhancements:
- Add Storybook stories for SignInForm and SignUpForm

Tests:
- Add unit tests covering sign-in and sign-up form behavior and error handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced sign-in and sign-up forms for user authentication, including error handling and success callbacks.
  - Added Storybook stories for both forms, enabling interactive previews and documentation.
- **Tests**
  - Added tests to verify that the sign-in and sign-up forms correctly handle user input and trigger authentication actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->