### PR TITLE
[Codex] Add invite auth form component

### DIFF
--- a/apps/web/src/components/InviteAuthForm.stories.tsx
+++ b/apps/web/src/components/InviteAuthForm.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { InviteAuthForm } from './InviteAuthForm'
+
+const meta: Meta<typeof InviteAuthForm> = {
+  component: InviteAuthForm,
+  title: 'Components/InviteAuthForm',
+  args: { token: 'abcd' }
+}
+export default meta
+
+type Story = StoryObj<typeof InviteAuthForm>
+
+export const Default: Story = {}

--- a/apps/web/src/components/InviteAuthForm.tsx
+++ b/apps/web/src/components/InviteAuthForm.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { type FormEvent, type FC, useState } from 'react'
+import { getSupabaseClient } from '@/utils/supabase'
+
+/** Props for {@link InviteAuthForm}. */
+export interface InviteAuthFormProps {
+  /** Invite token from the email link. */
+  token: string
+  /** Called when the invite is accepted successfully. */
+  onSuccess?: () => void
+}
+
+/**
+ * Lets a user complete sign up via an invite token.
+ */
+export const InviteAuthForm: FC<InviteAuthFormProps> = ({ token, onSuccess }) => {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setError(null)
+    const { error: verifyError } = await getSupabaseClient().auth.verifyOtp({
+      email,
+      token,
+      type: 'invite'
+    })
+    if (verifyError) {
+      setError(verifyError.message)
+      return
+    }
+    const { error: updateError } = await getSupabaseClient().auth.updateUser({
+      password
+    })
+    if (updateError) {
+      setError(updateError.message)
+      return
+    }
+    onSuccess?.()
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="flex flex-col gap-2">
+        <label htmlFor="invite-email">Email</label>
+        <input
+          id="invite-email"
+          type="email"
+          className="rounded border px-2 py-1"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+          required
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        <label htmlFor="invite-password">Password</label>
+        <input
+          id="invite-password"
+          type="password"
+          className="rounded border px-2 py-1"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          required
+        />
+      </div>
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      <button type="submit" className="rounded bg-primary px-4 py-2 text-white">
+        Join 🎉
+      </button>
+    </form>
+  )
+}

--- a/apps/web/src/components/__tests__/InviteAuthForm.test.tsx
+++ b/apps/web/src/components/__tests__/InviteAuthForm.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi } from 'vitest'
+
+const verifyOtp = vi.fn(async () => ({ data: null, error: null }))
+const updateUser = vi.fn(async () => ({ data: null, error: null }))
+vi.mock('../../utils/supabase', () => ({
+  getSupabaseClient: () => ({ auth: { verifyOtp, updateUser } })
+}))
+
+import { InviteAuthForm } from '../InviteAuthForm'
+
+describe('InviteAuthForm', () => {
+  it('verifies invite and sets password', async () => {
+    render(<InviteAuthForm token="tok" />)
+    await userEvent.type(screen.getByLabelText(/email/i), 'a@b.com')
+    await userEvent.type(screen.getByLabelText(/password/i), 'secret')
+    await userEvent.click(screen.getByRole('button', { name: /join/i }))
+    expect(verifyOtp).toHaveBeenCalledWith({
+      email: 'a@b.com',
+      token: 'tok',
+      type: 'invite'
+    })
+    expect(updateUser).toHaveBeenCalledWith({ password: 'secret' })
+  })
+})


### PR DESCRIPTION
## Summary
- add InviteAuthForm for accepting Supabase invite tokens
- test InviteAuthForm interactions
- document component via Storybook story

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`


------
https://chatgpt.com/codex/tasks/task_e_6877f3d1e2048326bc1d3d4ade577c12