### PR TITLE
[Codex] Add user menu auth component

### DIFF
--- a/apps/web/src/components/UserMenu.stories.tsx
+++ b/apps/web/src/components/UserMenu.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { UserMenu } from './UserMenu'
+
+const meta: Meta<typeof UserMenu> = {
+  component: UserMenu,
+  title: 'Components/UserMenu'
+}
+export default meta
+
+type Story = StoryObj<typeof UserMenu>
+
+export const Default: Story = {}

--- a/apps/web/src/components/UserMenu.tsx
+++ b/apps/web/src/components/UserMenu.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useState, useEffect, type FC } from 'react'
+import Link from 'next/link'
+import { getSupabaseClient } from '@/utils/supabase'
+
+/** Props for {@link UserMenu}. */
+export type UserMenuProps = Record<string, never>
+
+/**
+ * Shows authentication options with sign in/up links or a sign out button.
+ */
+export const UserMenu: FC<UserMenuProps> = () => {
+  const [email, setEmail] = useState<string | null>(null)
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    const supabase = getSupabaseClient()
+    const fetchUser = async () => {
+      const { data } = await supabase.auth.getUser()
+      setEmail(data.user?.email ?? null)
+    }
+    fetchUser()
+    const {
+      data: { subscription }
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setEmail(session?.user?.email ?? null)
+    })
+    return () => {
+      subscription.unsubscribe()
+    }
+  }, [])
+
+  const handleSignOut = async () => {
+    await getSupabaseClient().auth.signOut()
+    setEmail(null)
+    setOpen(false)
+  }
+
+  return (
+    <div className="relative">
+      <button
+        className="rounded px-3 py-2"
+        onClick={() => setOpen(!open)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        {email ?? 'Account'}
+      </button>
+      {open && (
+        <ul className="absolute right-0 mt-2 w-48 rounded border bg-background text-foreground shadow">
+          {email ? (
+            <li>
+              <button
+                role="menuitem"
+                onClick={handleSignOut}
+                className="block w-full px-4 py-2 text-left hover:bg-muted"
+              >
+                Sign Out
+              </button>
+            </li>
+          ) : (
+            <>
+              <li>
+                <Link role="menuitem" className="block px-4 py-2 hover:bg-muted" href="/signin">
+                  Sign In
+                </Link>
+              </li>
+              <li>
+                <Link role="menuitem" className="block px-4 py-2 hover:bg-muted" href="/signup">
+                  Sign Up
+                </Link>
+              </li>
+            </>
+          )}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/__tests__/UserMenu.test.tsx
+++ b/apps/web/src/components/__tests__/UserMenu.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi } from 'vitest'
+
+const signOut = vi.fn(async () => ({ error: null }))
+const onAuthStateChange = vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } }))
+const getUser = vi.fn(async () => ({ data: { user: { email: 'a@b.com' } } }))
+
+vi.mock('../../utils/supabase', () => ({
+  getSupabaseClient: () => ({ auth: { signOut, onAuthStateChange, getUser } })
+}))
+
+import { UserMenu } from '../UserMenu'
+
+describe('UserMenu', () => {
+  it('signs out when clicked', async () => {
+    render(<UserMenu />)
+    await screen.findByRole('button', { name: 'a@b.com' })
+    await userEvent.click(screen.getByRole('button', { name: 'a@b.com' }))
+    await userEvent.click(screen.getByRole('menuitem', { name: /sign out/i }))
+    expect(signOut).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- build UserMenu component for auth
- test the new user menu
- add storybook story for user menu

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`


------
https://chatgpt.com/codex/tasks/task_e_687801529d4483268e1efbc5f98f3b70

## Summary by Sourcery

Introduce a UserMenu component that integrates with Supabase to display authentication options, complete with Storybook documentation and unit tests

New Features:
- Add UserMenu component for authentication with sign in, sign up, and sign out flows

Documentation:
- Add Storybook story for the UserMenu component

Tests:
- Add unit tests for the UserMenu component to verify auth state changes and UI rendering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a user menu component that displays authentication options, including sign in, sign up, and sign out.
* **Tests**
  * Added tests to verify the user menu's sign-out functionality.
* **Documentation**
  * Added a Storybook story to showcase the user menu component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->