### PR TITLE
[Codex] Add auth page routes

### DIFF
--- a/apps/web/src/app/__tests__/invite.test.tsx
+++ b/apps/web/src/app/__tests__/invite.test.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import InvitePage from '../invite/[token]/page'
+
+test('passes token to invite form', () => {
+  render(<InvitePage params={{ token: 'abc' }} />)
+  expect(screen.getByRole('button', { name: /join/i })).toBeInTheDocument()
+})

--- a/apps/web/src/app/__tests__/signin.test.tsx
+++ b/apps/web/src/app/__tests__/signin.test.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import SignInPage from '../signin/page'
+
+test('renders sign in form', () => {
+  render(<SignInPage />)
+  expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument()
+})

--- a/apps/web/src/app/__tests__/signup.test.tsx
+++ b/apps/web/src/app/__tests__/signup.test.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import SignUpPage from '../signup/page'
+
+test('renders sign up form', () => {
+  render(<SignUpPage />)
+  expect(screen.getByRole('button', { name: /sign up/i })).toBeInTheDocument()
+})

--- a/apps/web/src/app/invite/[token]/page.tsx
+++ b/apps/web/src/app/invite/[token]/page.tsx
@@ -1,0 +1,14 @@
+import { InviteAuthForm } from '@/components/InviteAuthForm'
+
+/** Page for completing an invite with a token. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default function InvitePage({ params }: any) {
+  return (
+    <main className="grid flex-1 place-content-center p-8">
+      <section className="w-full max-w-sm space-y-4">
+        <h1 className="text-center text-2xl font-bold">Finish setting up</h1>
+        <InviteAuthForm token={params.token} />
+      </section>
+    </main>
+  )
+}

--- a/apps/web/src/app/signin/page.tsx
+++ b/apps/web/src/app/signin/page.tsx
@@ -1,0 +1,13 @@
+import { SignInForm } from '@/components/SignInForm'
+
+/** Page allowing users to sign in. */
+export default function SignInPage() {
+  return (
+    <main className="grid flex-1 place-content-center p-8">
+      <section className="w-full max-w-sm space-y-4">
+        <h1 className="text-center text-2xl font-bold">Welcome back</h1>
+        <SignInForm />
+      </section>
+    </main>
+  )
+}

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -1,0 +1,13 @@
+import { SignUpForm } from '@/components/SignUpForm'
+
+/** Page allowing users to register. */
+export default function SignUpPage() {
+  return (
+    <main className="grid flex-1 place-content-center p-8">
+      <section className="w-full max-w-sm space-y-4">
+        <h1 className="text-center text-2xl font-bold">Join Polymap 🎉</h1>
+        <SignUpForm />
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- add SignIn, SignUp and Invite pages
- test auth page routes

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_687806d92bd88326aa81276f2c329205