### PR TITLE
[Codex] add auth callback route

### DIFF
--- a/apps/web/src/app/__tests__/auth-callback.test.tsx
+++ b/apps/web/src/app/__tests__/auth-callback.test.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react'
+import { render } from '@testing-library/react'
+import { waitFor, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+
+const exchangeCodeForSession = vi.fn(async () => ({ error: null }))
+const replace = vi.fn()
+
+vi.mock('../../utils/supabase', () => ({
+  getSupabaseClient: () => ({ auth: { exchangeCodeForSession } })
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace }),
+  useSearchParams: () => new URLSearchParams('code=abc')
+}))
+
+import AuthCallbackPage from '../auth/callback/page'
+
+test('exchanges code and redirects', async () => {
+  render(<AuthCallbackPage />)
+  await waitFor(() => {
+    expect(exchangeCodeForSession).toHaveBeenCalledWith('abc')
+    expect(replace).toHaveBeenCalledWith('/')
+  })
+  expect(screen.getByText(/redirecting/i)).toBeInTheDocument()
+})

--- a/apps/web/src/app/auth/callback/AuthCallbackClient.tsx
+++ b/apps/web/src/app/auth/callback/AuthCallbackClient.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+
+import { getSupabaseClient } from '@/utils/supabase'
+
+/**
+ * Exchanges the OAuth code for a session then redirects the user.
+ */
+export function AuthCallbackClient() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  useEffect(() => {
+    const handleAuth = async () => {
+      const code = searchParams.get('code')
+      if (!code) {
+        router.replace('/signin')
+        return
+      }
+      const { error } = await getSupabaseClient().auth.exchangeCodeForSession(code)
+      router.replace(error ? '/signin' : '/')
+    }
+    void handleAuth()
+  }, [searchParams, router])
+
+  return (
+    <main className="grid flex-1 place-content-center p-8">
+      <p>Redirecting…</p>
+    </main>
+  )
+}

--- a/apps/web/src/app/auth/callback/page.tsx
+++ b/apps/web/src/app/auth/callback/page.tsx
@@ -1,0 +1,20 @@
+import { Suspense } from 'react'
+import type { Metadata } from 'next'
+import { AuthCallbackClient } from './AuthCallbackClient'
+
+/** Metadata for the auth callback page. */
+export const metadata: Metadata = {
+  title: 'Auth callback - Polymap',
+  description: 'Completes authentication and redirects you.',
+}
+
+/**
+ * Wrapper page for the client-side auth handler.
+ */
+export default function AuthCallbackPage() {
+  return (
+    <Suspense>
+      <AuthCallbackClient />
+    </Suspense>
+  )
+}


### PR DESCRIPTION
## Summary
- add a client component to handle auth callback
- wrap client component in new /auth/callback route
- test auth callback behavior

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6878b5a321a88326876861d12b82ec5d

## Summary by Sourcery

Add a client-side auth callback flow and route to exchange OAuth codes for Supabase sessions and redirect users, and include tests for the callback behavior

New Features:
- Introduce AuthCallbackClient component to handle OAuth code exchange and redirect logic
- Create a new Next.js /auth/callback page wrapping the auth callback client component

Tests:
- Add tests for the auth callback behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an authentication callback page that handles OAuth redirects and session exchange.
  * Users are automatically redirected to the appropriate page after authentication, with a "Redirecting…" message displayed during the process.

* **Tests**
  * Added tests to verify the authentication callback flow and redirection behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->