### PR TITLE
[Codex] Add dashboard auth route

### DIFF
--- a/apps/web/src/app/__tests__/dashboard-auth.test.tsx
+++ b/apps/web/src/app/__tests__/dashboard-auth.test.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import DashboardAuthPage from '../dashboard/auth/page'
+
+test('renders dashboard sign in form', () => {
+  render(<DashboardAuthPage />)
+  expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument()
+})

--- a/apps/web/src/app/dashboard/auth/page.tsx
+++ b/apps/web/src/app/dashboard/auth/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next'
+import { SignInForm } from '@/components/SignInForm'
+
+/** Metadata for the dashboard auth page. */
+export const metadata: Metadata = {
+  title: 'Dashboard login - Polymap',
+  description: 'Authenticate to manage your polycule dashboard.'
+}
+
+/** Page prompting users to sign in before accessing the dashboard. */
+export default function DashboardAuthPage() {
+  return (
+    <main className="grid flex-1 place-content-center p-8">
+      <section className="w-full max-w-sm space-y-4">
+        <h1 className="text-center text-2xl font-bold">Sign in to Dashboard 🔐</h1>
+        <SignInForm />
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- add dashboard auth page route
- test dashboard auth route

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6878bbb8c13083269173a8633195e3de

## Summary by Sourcery

Add a new dashboard authentication page component with title and description metadata, and include a sign-in form with accompanying tests

New Features:
- Add a dashboard authentication page route with metadata for login

Tests:
- Add unit test for the dashboard auth route

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated dashboard authentication page with a sign-in form and descriptive metadata.

* **Tests**
  * Added a test to verify that the sign-in form appears correctly on the dashboard authentication page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->