### PR TITLE
[Codex] Add dashboard page route

### DIFF
--- a/apps/web/src/app/__tests__/dashboard.test.tsx
+++ b/apps/web/src/app/__tests__/dashboard.test.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import DashboardPage from '../dashboard/page'
+
+test('renders dashboard heading', () => {
+  render(<DashboardPage />)
+  expect(screen.getByRole('heading', { name: /dashboard/i })).toBeInTheDocument()
+})

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next'
+
+/** Metadata for the dashboard page. */
+export const metadata: Metadata = {
+  title: 'Dashboard - Polymap',
+  description: 'Overview of your polycule maps.'
+}
+
+/** Page displaying the user dashboard. */
+export default function DashboardPage() {
+  return (
+    <main className="grid flex-1 place-content-center p-8">
+      <h1 className="text-2xl font-bold">Dashboard 🗺️</h1>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- add a /dashboard route
- test dashboard route

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6878c0b0855c83268da1f4906ed46570

## Summary by Sourcery

Add a new dashboard page under /dashboard with metadata and placeholder UI, and include tests for the route

New Features:
- Introduce a DashboardPage component at /dashboard with metadata

Tests:
- Add initial tests for the dashboard route

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new dashboard page displaying a central heading and improved metadata for better SEO and navigation.

* **Tests**
  * Added a test to verify the dashboard page renders correctly with the expected heading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->