### PR TITLE
[Codex] add middleware for supabase user

### DIFF
--- a/apps/web/src/__tests__/middleware.test.ts
+++ b/apps/web/src/__tests__/middleware.test.ts
@@ -1,0 +1,32 @@
+import { NextRequest } from 'next/server'
+import { afterEach, beforeEach, vi } from 'vitest'
+
+const getUser = vi.fn(async () => ({ data: { user: { id: '1' } } }))
+vi.mock('@supabase/auth-helpers-nextjs', () => ({
+  createMiddlewareClient: () => ({ auth: { getUser } })
+}))
+
+import { middleware } from '../middleware'
+
+describe('middleware', () => {
+  const env = process.env
+
+  beforeEach(() => {
+    process.env = {
+      ...env,
+      NEXT_PUBLIC_SUPABASE_URL: 'http://localhost',
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: 'anon'
+    }
+  })
+
+  afterEach(() => {
+    process.env = env
+  })
+
+  it('sets user header when session exists', async () => {
+    const req = new NextRequest('http://localhost/')
+    const res = await middleware(req)
+    expect(getUser).toHaveBeenCalled()
+    expect(res.headers.get('x-user-id')).toBe('1')
+  })
+})

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,0 +1,24 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { createMiddlewareClient } from '@supabase/auth-helpers-nextjs'
+
+/**
+ * Refreshes the Supabase session and exposes the user ID on each response.
+ */
+export async function middleware(req: NextRequest) {
+  const res = NextResponse.next()
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  if (!url || !key) return res
+
+  const supabase = createMiddlewareClient({ req, res })
+  const {
+    data: { user }
+  } = await supabase.auth.getUser()
+  if (user?.id) res.headers.set('x-user-id', user.id)
+  return res
+}
+
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)']
+}


### PR DESCRIPTION
## Summary
- attach Supabase user to each request via middleware
- test middleware behaviour

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`


------
https://chatgpt.com/codex/tasks/task_e_687d41d8f5108326b6784dc76b6b9e5b

## Summary by Sourcery

Add Supabase authentication middleware to the Next.js app to refresh sessions and expose user IDs on each response, and include tests for its behavior

New Features:
- Attach Supabase user to each request via Next.js middleware by setting an x-user-id header

Tests:
- Add unit tests to verify the Supabase middleware refreshes sessions and correctly handles user IDs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced middleware that adds a custom header with the authenticated user's ID to responses when a session exists.
* **Tests**
  * Added tests to verify that the middleware correctly sets the user ID header for authenticated users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->