### PR TITLE
[Codex] Protect dashboard and map pages

### DIFF
--- a/apps/web/src/app/__tests__/dashboard.test.tsx
+++ b/apps/web/src/app/__tests__/dashboard.test.tsx
@@ -1,8 +1,10 @@
-import * as React from 'react'
 import { render, screen } from '@testing-library/react'
 import DashboardPage from '../dashboard/page'
+import { vi } from 'vitest'
 
-test('renders dashboard heading', () => {
-  render(<DashboardPage />)
+vi.mock('../../utils/auth', () => ({ requireAuthentication: vi.fn() }))
+
+test('renders dashboard heading', async () => {
+  render(await DashboardPage())
   expect(screen.getByRole('heading', { name: /dashboard/i })).toBeInTheDocument()
 })

--- a/apps/web/src/app/__tests__/map.test.tsx
+++ b/apps/web/src/app/__tests__/map.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react'
+import MapPage from '../map/page'
+import { vi } from 'vitest'
+
+vi.mock('../../utils/auth', () => ({ requireAuthentication: vi.fn() }))
+
+test('renders map heading', async () => {
+  render(await MapPage())
+  expect(screen.getByRole('heading', { name: /map editor/i })).toBeInTheDocument()
+})

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import { requireAuthentication } from '@/utils/auth'
 
 /** Metadata for the dashboard page. */
 export const metadata: Metadata = {
@@ -7,7 +8,8 @@ export const metadata: Metadata = {
 }
 
 /** Page displaying the user dashboard. */
-export default function DashboardPage() {
+export default async function DashboardPage() {
+  await requireAuthentication()
   return (
     <main className="grid flex-1 place-content-center p-8">
       <h1 className="text-2xl font-bold">Dashboard 🗺️</h1>

--- a/apps/web/src/app/map/page.tsx
+++ b/apps/web/src/app/map/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next'
+import { requireAuthentication } from '@/utils/auth'
+
+/** Metadata for the map editor page. */
+export const metadata: Metadata = {
+  title: 'Map - Polymap',
+  description: 'Build and explore your polycule map.'
+}
+
+/** Page displaying the map editor. */
+export default async function MapPage() {
+  await requireAuthentication()
+  return (
+    <main className="grid flex-1 place-content-center p-8">
+      <h1 className="text-2xl font-bold">Map Editor 🗺️</h1>
+    </main>
+  )
+}

--- a/apps/web/src/utils/__tests__/auth.test.ts
+++ b/apps/web/src/utils/__tests__/auth.test.ts
@@ -1,0 +1,24 @@
+import { vi } from 'vitest'
+
+const headersMock = vi.fn()
+vi.mock('next/headers', () => ({ headers: () => headersMock() }))
+const redirectMock = vi.fn()
+vi.mock('next/navigation', () => ({ redirect: (...args: unknown[]) => redirectMock(...args) }))
+
+import { requireAuthentication } from '../auth'
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+it('redirects when user header missing', async () => {
+  headersMock.mockResolvedValue(new Headers())
+  await requireAuthentication()
+  expect(redirectMock).toHaveBeenCalledWith('/signin')
+})
+
+it('does nothing when user header present', async () => {
+  headersMock.mockResolvedValue(new Headers({ 'x-user-id': '1' }))
+  await requireAuthentication()
+  expect(redirectMock).not.toHaveBeenCalled()
+})

--- a/apps/web/src/utils/auth.ts
+++ b/apps/web/src/utils/auth.ts
@@ -1,0 +1,15 @@
+import { headers } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+/**
+ * Redirects unauthenticated requests to the sign in page.
+ *
+ * The middleware exposes the authenticated user via the `x-user-id` header.
+ */
+export async function requireAuthentication(): Promise<void> {
+  const hdrs = await headers()
+  const userId = hdrs.get('x-user-id')
+  if (!userId) {
+    redirect('/signin')
+  }
+}


### PR DESCRIPTION
## Summary
- add `requireAuthentication` helper
- secure dashboard and map pages using session header
- create map page
- test new auth helper and pages

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_687d4cefa32c832699f40150f5a1b557

## Summary by Sourcery

Enforce authentication on dashboard and newly created map pages by introducing a requireAuthentication utility, applying it to the pages, and adding corresponding tests.

New Features:
- Add requireAuthentication helper to enforce session-based access control
- Protect dashboard page by redirecting unauthenticated users to the sign-in page
- Introduce a new Map Editor page under /app/map guarded by authentication

Tests:
- Add unit tests for the requireAuthentication helper
- Add tests for protected dashboard and map pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a Map Editor page, accessible only to authenticated users, with dedicated metadata and a new interface.
  * Implemented authentication enforcement for the Dashboard and Map pages, redirecting unauthenticated users to the sign-in page.

* **Bug Fixes**
  * Improved authentication handling to ensure only authorised users can access protected pages.

* **Tests**
  * Added and updated tests for authentication logic and page access control to ensure correct redirection and access behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->