### PR TITLE
[Codex] Add sign out menu to header

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -5,7 +5,11 @@ export default defineConfig({
   webServer: {
     command: 'yarn build && yarn start -p 3000',
     port: 3000,
-    reuseExistingServer: !process.env.CI
+    reuseExistingServer: !process.env.CI,
+    env: {
+      NEXT_PUBLIC_SUPABASE_URL: 'http://localhost:54321',
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: 'test'
+    }
   },
   use: {
     baseURL: 'http://localhost:3000'

--- a/apps/web/src/app/__tests__/layout.test.tsx
+++ b/apps/web/src/app/__tests__/layout.test.tsx
@@ -7,6 +7,15 @@ vi.mock('next/font/google', () => ({
   Geist_Mono: () => ({ variable: '' })
 }));
 
+vi.mock('../../actions/auth', () => ({ signOut: vi.fn() }));
+const signOut = vi.fn(async () => ({ error: null }));
+const onAuthStateChange = vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } }));
+const getUser = vi.fn(async () => ({ data: { user: null } }));
+
+vi.mock('../../utils/supabase', () => ({
+  getSupabaseClient: () => ({ auth: { signOut, onAuthStateChange, getUser } })
+}));
+
 import RootLayout from '../layout';
 
 it('renders children', () => {

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import type { FC } from 'react';
+import { UserMenu } from '@/components/UserMenu';
 
 /** Props for {@link Header}. */
 export interface HeaderProps {
@@ -10,14 +11,15 @@ export interface HeaderProps {
 }
 
 /**
- * Renders the application header with a home link.
+ * Renders the application header with a home link and user menu.
  */
 export const Header: FC<HeaderProps> = ({ title }) => {
   return (
-    <header className="bg-background text-foreground px-4 py-2">
+    <header className="bg-background text-foreground flex items-center justify-between px-4 py-2">
       <Link className="text-xl font-bold no-underline" href="/">
         {title}
       </Link>
+      <UserMenu />
     </header>
   );
 };

--- a/apps/web/src/components/__tests__/Header.test.tsx
+++ b/apps/web/src/components/__tests__/Header.test.tsx
@@ -1,4 +1,15 @@
 import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+
+vi.mock('../../actions/auth', () => ({ signOut: vi.fn() }));
+const signOut = vi.fn(async () => ({ error: null }));
+const onAuthStateChange = vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } }));
+const getUser = vi.fn(async () => ({ data: { user: null } }));
+
+vi.mock('../../utils/supabase', () => ({
+  getSupabaseClient: () => ({ auth: { signOut, onAuthStateChange, getUser } })
+}));
+
 import { Header } from '../Header';
 
 describe('Header', () => {
@@ -6,6 +17,11 @@ describe('Header', () => {
     render(<Header title="Polymap" />);
     const link = screen.getByRole('link', { name: 'Polymap' });
     expect(link).toHaveAttribute('href', '/');
+  });
+
+  it('shows user menu', () => {
+    render(<Header title="Polymap" />);
+    expect(screen.getByRole('button', { name: 'Account' })).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Summary
- integrate `UserMenu` inside `Header`
- mock Supabase in layout and header tests
- set test Supabase env vars for Playwright

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_687e260806bc83269ae5f437f06fffb8

## Summary by Sourcery

Add a sign-out menu to the header by integrating the UserMenu component, update the Header layout, and enhance tests and e2e configuration to mock Supabase for test environments

New Features:
- Integrate UserMenu into Header for user account actions

Enhancements:
- Adjust Header layout to a flex container to accommodate the UserMenu

CI:
- Configure Supabase test environment variables in Playwright for e2e

Tests:
- Add unit test to verify the UserMenu button is visible in Header
- Mock Supabase in layout and header tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a user menu to the header for improved account access.

* **Bug Fixes**
  * Enhanced test reliability by mocking authentication functions in layout and header component tests.

* **Chores**
  * Updated Playwright configuration to set environment variables for local testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->