### PR TITLE
[Codex] enforce email verification before map access

### DIFF
--- a/apps/web/src/app/__tests__/verify-email.test.tsx
+++ b/apps/web/src/app/__tests__/verify-email.test.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import VerifyEmailPage from '../verify-email/page'
+
+test('renders verify email heading', () => {
+  render(<VerifyEmailPage />)
+  expect(
+    screen.getByRole('heading', { name: /verify your email/i })
+  ).toBeInTheDocument()
+})

--- a/apps/web/src/app/verify-email/page.tsx
+++ b/apps/web/src/app/verify-email/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from 'next'
+
+/** Metadata for the verify email page. */
+export const metadata: Metadata = {
+  title: 'Verify Email - Polymap',
+  description: 'Confirm your email to access maps.'
+}
+
+/** Page prompting the user to verify their email address. */
+export default function VerifyEmailPage() {
+  return (
+    <main className="grid flex-1 place-content-center p-8 space-y-4 text-center">
+      <h1 className="text-2xl font-bold">Verify your email 📧</h1>
+      <p>Check your inbox and refresh once verified.</p>
+    </main>
+  )
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -15,7 +15,12 @@ export async function middleware(req: NextRequest) {
   const {
     data: { user }
   } = await supabase.auth.getUser()
-  if (user?.id) res.headers.set('x-user-id', user.id)
+  if (user?.id) {
+    res.headers.set('x-user-id', user.id)
+    if (user.email_confirmed_at) {
+      res.headers.set('x-email-verified', 'true')
+    }
+  }
   return res
 }
 

--- a/apps/web/src/utils/__tests__/auth.test.ts
+++ b/apps/web/src/utils/__tests__/auth.test.ts
@@ -17,8 +17,16 @@ it('redirects when user header missing', async () => {
   expect(redirectMock).toHaveBeenCalledWith('/signin')
 })
 
-it('does nothing when user header present', async () => {
+it('redirects when email not verified', async () => {
   headersMock.mockResolvedValue(new Headers({ 'x-user-id': '1' }))
+  await requireAuthentication()
+  expect(redirectMock).toHaveBeenCalledWith('/verify-email')
+})
+
+it('does nothing when verified', async () => {
+  headersMock.mockResolvedValue(
+    new Headers({ 'x-user-id': '1', 'x-email-verified': 'true' })
+  )
   await requireAuthentication()
   expect(redirectMock).not.toHaveBeenCalled()
 })

--- a/apps/web/src/utils/auth.ts
+++ b/apps/web/src/utils/auth.ts
@@ -12,4 +12,8 @@ export async function requireAuthentication(): Promise<void> {
   if (!userId) {
     redirect('/signin')
   }
+  const verified = hdrs.get('x-email-verified')
+  if (verified !== 'true') {
+    redirect('/verify-email')
+  }
 }


### PR DESCRIPTION
## Summary
- add verify email page
- enforce verification in middleware and util
- test verification flow

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`


------
https://chatgpt.com/codex/tasks/task_e_687e3446711c8326bccc98e092f93a45

## Summary by Sourcery

Enforce email verification before granting map access by extending middleware and authentication util to check confirmation status, adding a verification page, and updating tests for the new flow

New Features:
- Add a Verify Email page to prompt users to confirm their email before accessing maps

Enhancements:
- Inject ‘x-email-verified’ header in middleware when user’s email is confirmed
- Enforce email verification in requireAuthentication util by redirecting unverified users to /verify-email

Tests:
- Add tests to cover redirection for unverified users and allow access when email is verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated page prompting users to verify their email address before accessing maps.
* **Enhancements**
  * Users are now required to have a verified email to proceed; unverified users are redirected to the email verification page.
  * Added visible messaging and improved handling for email verification status.
* **Tests**
  * Expanded and refined test coverage for email verification and authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->