### PR TITLE
[Codex] restrict map access

### DIFF
--- a/apps/web/src/app/__tests__/map-route.test.ts
+++ b/apps/web/src/app/__tests__/map-route.test.ts
@@ -1,0 +1,34 @@
+import { NextRequest } from 'next/server'
+import { vi } from 'vitest'
+
+const getUser = vi.fn()
+const maybeSingle = vi.fn()
+
+vi.mock('@supabase/auth-helpers-nextjs', () => ({
+  createRouteHandlerClient: () => ({
+    auth: { getUser },
+    from: () => ({ select: () => ({ eq: () => ({ maybeSingle }) }) })
+  })
+}))
+
+import { GET } from '../api/maps/[id]/route'
+
+test('returns map data for user with access', async () => {
+  getUser.mockResolvedValueOnce({ data: { user: { id: '1' } } })
+  maybeSingle.mockResolvedValueOnce({ data: { id: '1' } })
+  const res = await GET(new NextRequest('http://localhost/api/maps/1'))
+  expect(res.status).toBe(200)
+})
+
+test('returns 401 when unauthenticated', async () => {
+  getUser.mockResolvedValueOnce({ data: { user: null } })
+  const res = await GET(new NextRequest('http://localhost/api/maps/1'))
+  expect(res.status).toBe(401)
+})
+
+test('returns 404 when no map found', async () => {
+  getUser.mockResolvedValueOnce({ data: { user: { id: '1' } } })
+  maybeSingle.mockResolvedValueOnce({ data: null })
+  const res = await GET(new NextRequest('http://localhost/api/maps/99'))
+  expect(res.status).toBe(404)
+})

--- a/apps/web/src/app/api/maps/[id]/route.ts
+++ b/apps/web/src/app/api/maps/[id]/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server'
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * Fetches a map if the authenticated user has access.
+ */
+export async function GET(request: Request) {
+  const supabase = createRouteHandlerClient({ cookies })
+  const {
+    data: { user }
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const url = new URL(request.url)
+  const id = url.pathname.split('/').pop() ?? ''
+
+  const { data, error } = await supabase
+    .from('maps')
+    .select('*')
+    .eq('id', id)
+    .maybeSingle()
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  if (!data) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  return NextResponse.json(data)
+}


### PR DESCRIPTION
## Summary
- add route to fetch maps only for signed-in users
- cover map route with unit tests

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_687e4d3d2cd88326ad77d0d52a929e4c