### PR TITLE
[Codex] add rate-limited magic link login

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,6 +29,7 @@
     "@testing-library/jest-dom": "^6",
     "@testing-library/react": "^15",
     "@testing-library/user-event": "^14",
+    "@types/lru-cache": "^7.10.10",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/apps/web/src/actions/__tests__/auth.test.ts
+++ b/apps/web/src/actions/__tests__/auth.test.ts
@@ -1,0 +1,18 @@
+import { vi, expect, it, describe } from 'vitest'
+
+vi.mock('@supabase/auth-helpers-nextjs', () => ({
+  createServerActionClient: () => ({
+    auth: { signInWithOtp: vi.fn(async () => ({ error: null })) }
+  })
+}))
+
+describe('sendMagicLink', () => {
+  it('prevents rapid repeated requests', async () => {
+    const { sendMagicLink } = await import('../auth')
+    const first = await sendMagicLink('a@b.com')
+    const second = await sendMagicLink('a@b.com')
+    expect(first.error).toBeNull()
+    expect(second.error).toMatch(/wait/i)
+  })
+})
+

--- a/apps/web/src/actions/auth.ts
+++ b/apps/web/src/actions/auth.ts
@@ -33,3 +33,16 @@ export async function signOut() {
   const supabase = createServerActionClient({ cookies })
   return supabase.auth.signOut()
 }
+
+/**
+ * Sends a magic login link if the rate limiter allows it.
+ */
+export async function sendMagicLink(email: string) {
+  const { rateLimiter } = await import('@/utils/rateLimit')
+  if (!rateLimiter.allow(email)) {
+    return { error: 'Please wait before requesting another link.' }
+  }
+  const supabase = createServerActionClient({ cookies })
+  const { error } = await supabase.auth.signInWithOtp({ email })
+  return { error: error?.message ?? null }
+}

--- a/apps/web/src/utils/rateLimit.ts
+++ b/apps/web/src/utils/rateLimit.ts
@@ -1,10 +1,19 @@
 import { LRUCache } from 'lru-cache'
 
-interface RateLimiter {
+/** Milliseconds before an entry expires. */
+const TTL_MS = 60_000
+
+/** Maximum number of keys to track. */
+const MAX_KEYS = 1000
+
+export interface RateLimiter {
+  /**
+   * Returns `true` if the action is allowed for the key.
+   */
   allow(key: string): boolean
 }
 
-const limiter = new LRUCache<string, true>({ max: 1000, ttl: 60_000 })
+const limiter = new LRUCache<string, true>({ max: MAX_KEYS, ttl: TTL_MS })
 
 /**
  * Simple rate limiter allowing one action per key per minute.

--- a/apps/web/src/utils/rateLimit.ts
+++ b/apps/web/src/utils/rateLimit.ts
@@ -1,0 +1,19 @@
+import { LRUCache } from 'lru-cache'
+
+interface RateLimiter {
+  allow(key: string): boolean
+}
+
+const limiter = new LRUCache<string, true>({ max: 1000, ttl: 60_000 })
+
+/**
+ * Simple rate limiter allowing one action per key per minute.
+ */
+export const rateLimiter: RateLimiter = {
+  allow(key: string) {
+    if (limiter.has(key)) return false
+    limiter.set(key, true)
+    return true
+  }
+}
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -1672,6 +1672,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/lru-cache@npm:^7.10.10":
+  version: 7.10.10
+  resolution: "@types/lru-cache@npm:7.10.10"
+  dependencies:
+    lru-cache: "npm:*"
+  checksum: 10c0/ab85558867cb059bebd42074c1cd517eb41efb1db22b9d26dfdc58df01c83ff9c212a562b4ec3d5936418ffb03e626a0f30463026aa5fb5ced41e3b4b4af057f
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:*":
   version: 24.0.14
   resolution: "@types/node@npm:24.0.14"
@@ -4993,6 +5002,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:*":
+  version: 11.1.0
+  resolution: "lru-cache@npm:11.1.0"
+  checksum: 10c0/85c312f7113f65fae6a62de7985348649937eb34fb3d212811acbf6704dc322a421788aca253b62838f1f07049a84cc513d88f494e373d3756514ad263670a64
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^10.0.1, lru-cache@npm:^10.2.0, lru-cache@npm:^10.4.3":
   version: 10.4.3
   resolution: "lru-cache@npm:10.4.3"
@@ -7327,6 +7343,7 @@ __metadata:
     "@testing-library/jest-dom": "npm:^6"
     "@testing-library/react": "npm:^15"
     "@testing-library/user-event": "npm:^14"
+    "@types/lru-cache": "npm:^7.10.10"
     "@types/node": "npm:^20"
     "@types/react": "npm:^19"
     "@types/react-dom": "npm:^19"


### PR DESCRIPTION
## Summary
- add a small rate limiter util
- allow sending magic links via server action with throttling
- cover magic link action with tests
- include typings for lru-cache

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn test --run vitest/__snapshots__`
- `yarn e2e:ci`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_687e903cf8dc8326b4580906e5e4c138

## Summary by Sourcery

Add rate-limited magic link login via a new server action

New Features:
- Introduce sendMagicLink action to throttle and send magic login links

Enhancements:
- Implement a simple LRUCache-based rate limiter utility
- Add TypeScript typings for lru-cache dependency

Tests:
- Add tests for magic link authentication and rate limiting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a rate limit to the magic login link feature, preventing users from requesting multiple links within a short period.
* **Bug Fixes**
  * Improved user feedback by providing an error message if a magic link is requested too frequently.
* **Tests**
  * Added tests to verify rate limiting and correct error messaging for repeated magic link requests.
* **Chores**
  * Added a development dependency for type definitions related to caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->