### PR TITLE
[Codex] display email on dashboard

### DIFF
--- a/apps/web/src/app/__tests__/dashboard.test.tsx
+++ b/apps/web/src/app/__tests__/dashboard.test.tsx
@@ -2,9 +2,22 @@ import { render, screen } from '@testing-library/react'
 import DashboardPage from '../dashboard/page'
 import { vi } from 'vitest'
 
+const getUser = vi.fn()
+vi.mock('@supabase/auth-helpers-nextjs', () => ({
+  createServerComponentClient: () => ({ auth: { getUser } })
+}))
+
+getUser.mockResolvedValue({ data: { user: null } })
+
 vi.mock('../../utils/auth', () => ({ requireAuthentication: vi.fn() }))
 
 test('renders dashboard heading', async () => {
   render(await DashboardPage())
   expect(screen.getByRole('heading', { name: /dashboard/i })).toBeInTheDocument()
+})
+
+test('shows signed in email', async () => {
+  getUser.mockResolvedValueOnce({ data: { user: { email: 'a@b.com' } } })
+  render(await DashboardPage())
+  expect(screen.getByText('Signed in as a@b.com')).toBeInTheDocument()
 })

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next'
+import { cookies } from 'next/headers'
+import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
 import { requireAuthentication } from '@/utils/auth'
 
 /** Metadata for the dashboard page. */
@@ -10,9 +12,15 @@ export const metadata: Metadata = {
 /** Page displaying the user dashboard. */
 export default async function DashboardPage() {
   await requireAuthentication()
+  const supabase = createServerComponentClient({ cookies })
+  const {
+    data: { user }
+  } = await supabase.auth.getUser()
+  const email = user?.email ?? null
   return (
-    <main className="grid flex-1 place-content-center p-8">
+    <main className="grid flex-1 place-content-center space-y-2 p-8">
       <h1 className="text-2xl font-bold">Dashboard 🗺️</h1>
+      {email && <p>Signed in as {email}</p>}
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- show "Signed in as" message on dashboard using Supabase
- check that message appears in dashboard tests

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_687e9cb8efc483268ea284ea6e9dfb8f

## Summary by Sourcery

Fetch and display the signed-in user’s email on the dashboard using Supabase and update tests accordingly

New Features:
- Show a “Signed in as <email>” message on the dashboard when a user is authenticated

Enhancements:
- Add vertical spacing between dashboard elements

Tests:
- Mock Supabase auth.getUser in dashboard tests and verify the email message renders