### PR TITLE
[Codex] handle invite sign-up

### DIFF
--- a/apps/web/src/actions/__tests__/invite.test.ts
+++ b/apps/web/src/actions/__tests__/invite.test.ts
@@ -1,12 +1,26 @@
 import { vi, describe, it, expect } from 'vitest'
 
 const sign = vi.fn(() => 'tok')
-vi.mock('jsonwebtoken', () => ({ default: { sign } }))
+const verify = vi.fn(() => ({ email: 'a@b.com', mapId: '1', type: 'invite' }))
+vi.mock('jsonwebtoken', () => ({ default: { sign, verify } }))
 
 describe('generateInviteToken', () => {
-  it('creates token with expiry', async () => {
+  it('creates token with expiry and map ID', async () => {
     const { generateInviteToken } = await import('../invite')
-    generateInviteToken({ email: 'a@b.com', expiresIn: 123 })
-    expect(sign).toHaveBeenCalledWith({ email: 'a@b.com', type: 'invite' }, expect.any(String), { expiresIn: 123 })
+    generateInviteToken({ email: 'a@b.com', mapId: '1', expiresIn: 123 })
+    expect(sign).toHaveBeenCalledWith(
+      { email: 'a@b.com', mapId: '1', type: 'invite' },
+      expect.any(String),
+      { expiresIn: 123 }
+    )
+  })
+})
+
+describe('decodeInviteToken', () => {
+  it('returns payload when valid', async () => {
+    const { decodeInviteToken } = await import('../invite')
+    const payload = decodeInviteToken('tok')
+    expect(verify).toHaveBeenCalledWith('tok', expect.any(String))
+    expect(payload?.mapId).toBe('1')
   })
 })

--- a/apps/web/src/actions/invite.ts
+++ b/apps/web/src/actions/invite.ts
@@ -1,4 +1,4 @@
-'use server'
+
 
 import jwt from 'jsonwebtoken'
 
@@ -6,13 +6,51 @@ const jwtSecret = process.env.SUPABASE_JWT_SECRET ?? ''
 
 export interface InviteTokenParams {
   email: string
+  /** Map ID for the invitation. */
+  mapId: string
   /** Expiry time in seconds. Defaults to 10 minutes. */
   expiresIn?: number
+}
+
+export interface InvitePayload {
+  email: string
+  mapId: string
+  type: 'invite'
 }
 
 /**
  * Generates a short-lived invite JWT for the given email.
  */
-export function generateInviteToken({ email, expiresIn = 600 }: InviteTokenParams): string {
-  return jwt.sign({ email, type: 'invite' }, jwtSecret, { expiresIn })
+export function generateInviteToken({ email, mapId, expiresIn = 600 }: InviteTokenParams): string {
+  return jwt.sign({ email, mapId, type: 'invite' }, jwtSecret, { expiresIn })
+}
+
+/**
+ * Decodes an invite JWT returning the payload or null if invalid.
+ */
+export function decodeInviteToken(token: string): InvitePayload | null {
+  try {
+    return jwt.verify(token, jwtSecret) as InvitePayload
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Adds the current user as collaborator on a map using the invite token.
+ */
+export async function addCollaborator(token: string) {
+  const { createServerActionClient } = await import('@supabase/auth-helpers-nextjs')
+  const { cookies } = await import('next/headers')
+  const supabase = createServerActionClient({ cookies })
+  const payload = decodeInviteToken(token)
+  if (!payload) return { error: 'Invalid token' }
+  const {
+    data: { user }
+  } = await supabase.auth.getUser()
+  if (!user) return { error: 'Unauthorized' }
+  const { error } = await supabase
+    .from('map_collaborators')
+    .insert({ map_id: payload.mapId, user_id: user.id })
+  return { error: error?.message ?? null }
 }

--- a/apps/web/src/app/__tests__/invite-accept-route.test.ts
+++ b/apps/web/src/app/__tests__/invite-accept-route.test.ts
@@ -1,0 +1,30 @@
+import { NextRequest } from 'next/server'
+import { vi } from 'vitest'
+
+const getUser = vi.fn()
+const insert = vi.fn()
+
+vi.mock('@supabase/auth-helpers-nextjs', () => ({
+  createRouteHandlerClient: () => ({
+    auth: { getUser },
+    from: () => ({ insert })
+  })
+}))
+
+vi.mock('../../actions/invite', () => ({
+  decodeInviteToken: () => ({ email: 'a@b.com', mapId: '1', type: 'invite' })
+}))
+
+import { POST } from '../api/invite/accept/route'
+
+test('adds collaborator for authenticated user', async () => {
+  getUser.mockResolvedValueOnce({ data: { user: { id: '1' } } })
+  insert.mockResolvedValueOnce({ error: null })
+  const req = new NextRequest('http://localhost/api/invite/accept', {
+    method: 'POST',
+    body: JSON.stringify({ token: 'tok' })
+  })
+  const res = await POST(req)
+  expect(res.status).toBe(200)
+  expect(insert).toHaveBeenCalledWith({ map_id: '1', user_id: '1' })
+})

--- a/apps/web/src/app/__tests__/invite.test.tsx
+++ b/apps/web/src/app/__tests__/invite.test.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react'
 import { render, screen } from '@testing-library/react'
 import InvitePage from '../invite/[token]/page'
 
-test('passes token to invite form', () => {
-  render(<InvitePage params={{ token: 'abc' }} />)
+test('passes token to invite form', async () => {
+  render(await InvitePage({ params: { token: 'abc' } }))
   expect(screen.getByRole('button', { name: /join/i })).toBeInTheDocument()
 })
+

--- a/apps/web/src/app/api/invite/accept/route.ts
+++ b/apps/web/src/app/api/invite/accept/route.ts
@@ -1,0 +1,33 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+import { decodeInviteToken } from '@/actions/invite'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+/**
+ * Adds authenticated user as collaborator on the invited map.
+ */
+export async function POST(request: NextRequest) {
+  const { token } = await request.json()
+  const payload = decodeInviteToken(token)
+  if (!payload) {
+    return NextResponse.json({ error: 'Invalid token' }, { status: 400 })
+  }
+  const supabase = createRouteHandlerClient({ cookies })
+  const {
+    data: { user }
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const { error } = await supabase
+    .from('map_collaborators')
+    .insert({ map_id: payload.mapId, user_id: user.id })
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json({ success: true })
+}
+

--- a/apps/web/src/app/invite/[token]/page.tsx
+++ b/apps/web/src/app/invite/[token]/page.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from 'next'
 import { InviteAuthForm } from '@/components/InviteAuthForm'
+import { decodeInviteToken } from '@/actions/invite'
+import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
 
 /** Metadata for the invite page. */
 export const metadata: Metadata = {
@@ -9,13 +12,27 @@ export const metadata: Metadata = {
 
 /** Page for completing an invite with a token. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default function InvitePage({ params }: any) {
+export default async function InvitePage({ params }: any) {
+  const payload = decodeInviteToken(params.token)
+  let mapName: string | null = null
+  if (payload) {
+    const supabase = createServerComponentClient({ cookies })
+    const { data } = await supabase
+      .from('maps')
+      .select('name')
+      .eq('id', payload.mapId)
+      .maybeSingle()
+    mapName = (data as { name?: string } | null)?.name ?? null
+  }
   return (
     <main className="grid flex-1 place-content-center p-8">
       <section className="w-full max-w-sm space-y-4">
-        <h1 className="text-center text-2xl font-bold">Finish setting up</h1>
+        <h1 className="text-center text-2xl font-bold">
+          {mapName ? `Join ${mapName}` : 'Finish setting up'}
+        </h1>
         <InviteAuthForm token={params.token} />
       </section>
     </main>
   )
 }
+

--- a/apps/web/src/components/InviteAuthForm.tsx
+++ b/apps/web/src/components/InviteAuthForm.tsx
@@ -38,6 +38,16 @@ export const InviteAuthForm: FC<InviteAuthFormProps> = ({ token, onSuccess }) =>
       setError(updateError.message)
       return
     }
+    const res = await fetch('/api/invite/accept', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token })
+    })
+    if (!res.ok) {
+      const data = await res.json()
+      setError(data.error)
+      return
+    }
     onSuccess?.()
   }
 

--- a/apps/web/src/components/__tests__/InviteAuthForm.test.tsx
+++ b/apps/web/src/components/__tests__/InviteAuthForm.test.tsx
@@ -8,6 +8,10 @@ vi.mock('../../utils/supabase', () => ({
   getSupabaseClient: () => ({ auth: { verifyOtp, updateUser } })
 }))
 
+global.fetch = vi.fn(async () =>
+  new Response(JSON.stringify({ success: true }), { status: 200 })
+) as unknown as typeof fetch
+
 import { InviteAuthForm } from '../InviteAuthForm'
 
 describe('InviteAuthForm', () => {
@@ -22,5 +26,10 @@ describe('InviteAuthForm', () => {
       type: 'invite'
     })
     expect(updateUser).toHaveBeenCalledWith({ password: 'secret' })
+    expect(global.fetch).toHaveBeenCalledWith('/api/invite/accept', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: 'tok' })
+    })
   })
 })


### PR DESCRIPTION
## Summary
- decode invite tokens and add collaborators
- show map name on invite page
- create API route to accept invite
- test invite flows

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_687f3f7e51e48326966931210bd92b9f

## Summary by Sourcery

Implement end-to-end invite sign-up flow by decoding JWT tokens with map IDs, adding users as collaborators in Supabase, exposing a dedicated API endpoint for invite acceptance, updating the invite page UI to display the map name, and adding comprehensive tests.

New Features:
- Include mapId in invite JWT payload
- Add decodeInviteToken and addCollaborator server actions
- Create /api/invite/accept POST route to handle invite tokens
- Update InviteAuthForm to call the invite acceptance endpoint

Enhancements:
- Display the target map name on the invite landing page

Tests:
- Validate token generation and decoding in unit tests
- Test InviteAuthForm fetch call to the accept invite API
- Add tests for the invite acceptance API route

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
  * Introduced invite acceptance flow allowing users to join maps via invite tokens.
  * Added server-side validation and handling for invite tokens, including collaborator addition upon acceptance.
  * Invite acceptance page now dynamically displays the map name based on the invite token.

**Bug Fixes**
  * Improved error handling during invite acceptance, ensuring users receive feedback on failure.

**Tests**
  * Added and updated tests for invite token generation, decoding, acceptance API, and invite acceptance UI flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->