### PR TITLE
[Codex] Show welcome message on first login

### DIFF
--- a/apps/web/src/actions/auth.ts
+++ b/apps/web/src/actions/auth.ts
@@ -13,8 +13,16 @@ interface Credentials {
  */
 export async function signIn({ email, password }: Credentials) {
   const supabase = createServerActionClient({ cookies })
-  const { error } = await supabase.auth.signInWithPassword({ email, password })
-  return { error: error?.message ?? null }
+  const {
+    data,
+    error
+  } = await supabase.auth.signInWithPassword({ email, password })
+  let welcome = false
+  if (data.user?.user_metadata.firstLogin) {
+    welcome = true
+    await supabase.auth.updateUser({ data: { firstLogin: false } })
+  }
+  return { error: error?.message ?? null, welcome }
 }
 
 /**
@@ -22,7 +30,11 @@ export async function signIn({ email, password }: Credentials) {
  */
 export async function signUp({ email, password }: Credentials) {
   const supabase = createServerActionClient({ cookies })
-  const { error } = await supabase.auth.signUp({ email, password })
+  const { error } = await supabase.auth.signUp({
+    email,
+    password,
+    options: { data: { firstLogin: true } }
+  })
   return { error: error?.message ?? null }
 }
 

--- a/apps/web/src/components/SignInForm.tsx
+++ b/apps/web/src/components/SignInForm.tsx
@@ -16,14 +16,18 @@ export const SignInForm: FC<SignInFormProps> = ({ onSuccess }) => {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
+  const [welcome, setWelcome] = useState(false)
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     setError(null)
-    const { error } = await signIn({ email, password })
+    const { error, welcome: firstLogin } = await signIn({ email, password })
     if (error) {
       setError(error)
       return
+    }
+    if (firstLogin) {
+      setWelcome(true)
     }
     onSuccess?.()
   }
@@ -53,6 +57,9 @@ export const SignInForm: FC<SignInFormProps> = ({ onSuccess }) => {
         />
       </div>
       {error && <p className="text-sm text-red-600">{error}</p>}
+      {welcome && (
+        <p className="text-sm text-green-600">Welcome to Polymap 🎉</p>
+      )}
       <button type="submit" className="rounded bg-primary px-4 py-2 text-white">
         Sign In
       </button>

--- a/apps/web/src/components/__tests__/SignInForm.test.tsx
+++ b/apps/web/src/components/__tests__/SignInForm.test.tsx
@@ -2,7 +2,9 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
 
-vi.mock('../../actions/auth', () => ({ signIn: vi.fn(async () => ({ error: null })) }))
+vi.mock('../../actions/auth', () => ({
+  signIn: vi.fn(async () => ({ error: null, welcome: true }))
+}))
 import { signIn } from '../../actions/auth'
 
 import { SignInForm } from '../SignInForm'
@@ -14,5 +16,6 @@ describe('SignInForm', () => {
     await userEvent.type(screen.getByLabelText(/password/i), 'secret')
     await userEvent.click(screen.getByRole('button', { name: /sign in/i }))
     expect(signIn).toHaveBeenCalledWith({ email: 'a@b.com', password: 'secret' })
+    expect(screen.getByText(/welcome to polymap/i)).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- greet new users on their initial login
- store first-login state in Supabase user metadata
- test that the SignInForm renders the welcome message

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`
- `yarn build`
- `yarn workspace web start -p 0`

------
https://chatgpt.com/codex/tasks/task_e_687f8f36247883268dca9df5cf0fb249

## Summary by Sourcery

Greet new users with a welcome message on their initial login and manage first-login state in Supabase metadata.

New Features:
- Detect first-login in the sign-in action and return a welcome flag
- Initialize firstLogin metadata on user sign-up
- Render a welcome message in the SignInForm for first-time logins

Tests:
- Add a test to verify that the welcome message appears in the SignInForm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users now see a special welcome message on their first successful login.

* **Bug Fixes**
  * No user-facing bugs were addressed in this release.

* **Tests**
  * Updated tests to verify the welcome message appears for first-time users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->