### PR TITLE
[Codex] validate Supabase env vars

### DIFF
--- a/apps/web/src/utils/__tests__/supabase.test.ts
+++ b/apps/web/src/utils/__tests__/supabase.test.ts
@@ -1,5 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { getSupabaseClient } from '../supabase'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const ORIGINAL_ENV = process.env
 
@@ -10,11 +9,19 @@ describe('getSupabaseClient', () => {
 
   afterEach(() => {
     process.env = ORIGINAL_ENV
+    vi.resetModules()
   })
 
-  it('returns the same instance on multiple calls', () => {
+  it('returns the same instance on multiple calls', async () => {
+    const { getSupabaseClient } = await import('../supabase')
     const first = getSupabaseClient()
     const second = getSupabaseClient()
     expect(first).toBe(second)
+  })
+
+  it('throws when environment variables are missing', async () => {
+    process.env = {} as NodeJS.ProcessEnv
+    const { getSupabaseClient } = await import('../supabase')
+    expect(() => getSupabaseClient()).toThrow('Supabase credentials missing')
   })
 })

--- a/apps/web/src/utils/supabase.ts
+++ b/apps/web/src/utils/supabase.ts
@@ -7,8 +7,23 @@ let client: SupabaseClient | undefined
  * Returns a singleton Supabase client using environment configuration.
  */
 export const getSupabaseClient = (): SupabaseClient => {
-  if (!client) {
-    client = createClientComponentClient()
+  if (client) {
+    return client
   }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+  if (!supabaseUrl || !supabaseKey) {
+    throw new Error(
+      'Supabase credentials missing. Provide NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY.'
+    )
+  }
+
+  client = createClientComponentClient({
+    supabaseUrl,
+    supabaseKey,
+  })
+
   return client
 }


### PR DESCRIPTION
## Summary
- check Supabase environment variables when creating a client
- test error handling for missing credentials

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_687ff53380fc8326af3c09509e6bdfdb