### PR TITLE
[Codex] document supabase env requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,16 @@ yarn e2e:ci
 yarn build
 ```
 
+## Environment Variables
+
+Create an `.env.local` file inside `apps/web` and define Supabase credentials:
+
+```bash
+NEXT_PUBLIC_SUPABASE_URL=<your-url>
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-anon-key>
+```
+
+Without these values the application will fail to start.
+
 See [docs/architecture.md](docs/architecture.md) for an overview of the monorepo and [docs/styleguide.md](docs/styleguide.md) for coding standards.
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -2,7 +2,14 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
-First, run the development server:
+First, create an `.env.local` file with your Supabase credentials:
+
+```bash
+NEXT_PUBLIC_SUPABASE_URL=<your-url>
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-anon-key>
+```
+
+Then run the development server:
 
 ```bash
 npm run dev


### PR DESCRIPTION
## Summary
- explain required Supabase variables in main README
- note env setup in the web app README

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68810d314cc083269ee3c3fdb86dbdba

## Summary by Sourcery

Document the required Supabase environment variables for local development in the main README and the web app README.

Documentation:
- Add an Environment Variables section to the root README explaining how to set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY in .env.local
- Update the apps/web README to instruct creating an .env.local file with Supabase credentials before starting the development server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to include instructions for setting required Supabase environment variables before starting the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->