### PR TITLE
[Codex] add name and confirm password

### DIFF
--- a/apps/web/src/actions/auth.ts
+++ b/apps/web/src/actions/auth.ts
@@ -3,15 +3,19 @@
 import { createServerActionClient } from '@supabase/auth-helpers-nextjs'
 import { cookies } from 'next/headers'
 
-interface Credentials {
+interface SignInCredentials {
   email: string
   password: string
+}
+
+interface SignUpCredentials extends SignInCredentials {
+  name: string
 }
 
 /**
  * Signs the user in and stores the session in an HTTP-only cookie.
  */
-export async function signIn({ email, password }: Credentials) {
+export async function signIn({ email, password }: SignInCredentials) {
   const supabase = createServerActionClient({ cookies })
   const {
     data,
@@ -28,12 +32,12 @@ export async function signIn({ email, password }: Credentials) {
 /**
  * Registers the user and stores the session in an HTTP-only cookie.
  */
-export async function signUp({ email, password }: Credentials) {
+export async function signUp({ email, password, name }: SignUpCredentials) {
   const supabase = createServerActionClient({ cookies })
   const { error } = await supabase.auth.signUp({
     email,
     password,
-    options: { data: { firstLogin: true } }
+    options: { data: { firstLogin: true, name } }
   })
   return { error: error?.message ?? null }
 }

--- a/apps/web/src/components/SignUpForm.tsx
+++ b/apps/web/src/components/SignUpForm.tsx
@@ -13,14 +13,20 @@ export interface SignUpFormProps {
  * Collects email and password then registers the user via Supabase.
  */
 export const SignUpForm: FC<SignUpFormProps> = ({ onSuccess }) => {
+  const [name, setName] = useState('')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [confirm, setConfirm] = useState('')
   const [error, setError] = useState<string | null>(null)
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     setError(null)
-    const { error } = await signUp({ email, password })
+    if (password !== confirm) {
+      setError('Passwords do not match')
+      return
+    }
+    const { error } = await signUp({ email, password, name })
     if (error) {
       setError(error)
       return
@@ -30,6 +36,17 @@ export const SignUpForm: FC<SignUpFormProps> = ({ onSuccess }) => {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="flex flex-col gap-2">
+        <label htmlFor="signup-name">Name</label>
+        <input
+          id="signup-name"
+          type="text"
+          className="rounded border px-2 py-1"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          required
+        />
+      </div>
       <div className="flex flex-col gap-2">
         <label htmlFor="signup-email">Email</label>
         <input
@@ -49,6 +66,17 @@ export const SignUpForm: FC<SignUpFormProps> = ({ onSuccess }) => {
           className="rounded border px-2 py-1"
           value={password}
           onChange={e => setPassword(e.target.value)}
+          required
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        <label htmlFor="signup-confirm">Confirm Password</label>
+        <input
+          id="signup-confirm"
+          type="password"
+          className="rounded border px-2 py-1"
+          value={confirm}
+          onChange={e => setConfirm(e.target.value)}
           required
         />
       </div>

--- a/apps/web/src/components/__tests__/SignUpForm.test.tsx
+++ b/apps/web/src/components/__tests__/SignUpForm.test.tsx
@@ -10,9 +10,27 @@ import { SignUpForm } from '../SignUpForm'
 describe('SignUpForm', () => {
   it('calls signUp with provided credentials', async () => {
     render(<SignUpForm />)
+    await userEvent.type(screen.getByLabelText(/name/i), 'Alice')
     await userEvent.type(screen.getByLabelText(/email/i), 'c@d.com')
-    await userEvent.type(screen.getByLabelText(/password/i), 'secret')
+    await userEvent.type(screen.getByLabelText(/^password$/i), 'secret')
+    await userEvent.type(screen.getByLabelText(/confirm password/i), 'secret')
     await userEvent.click(screen.getByRole('button', { name: /sign up/i }))
-    expect(signUp).toHaveBeenCalledWith({ email: 'c@d.com', password: 'secret' })
+    expect(signUp).toHaveBeenCalledWith({
+      email: 'c@d.com',
+      password: 'secret',
+      name: 'Alice'
+    })
+  })
+
+  it('shows error if passwords do not match', async () => {
+    vi.mocked(signUp).mockClear()
+    render(<SignUpForm />)
+    await userEvent.type(screen.getByLabelText(/name/i), 'Bob')
+    await userEvent.type(screen.getByLabelText(/email/i), 'bob@a.com')
+    await userEvent.type(screen.getByLabelText(/^password$/i), 'secret')
+    await userEvent.type(screen.getByLabelText(/confirm password/i), 'other')
+    await userEvent.click(screen.getByRole('button', { name: /sign up/i }))
+    expect(screen.getByText(/passwords do not match/i)).toBeInTheDocument()
+    expect(signUp).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- extend auth sign up action to accept name and pass to Supabase
- update SignUpForm with name and confirm password fields
- validate confirmation before calling signUp
- test mismatched password case

## Test Plan
- `yarn lint --fix`
- `yarn typecheck`
- `yarn test`
- `yarn e2e:ci`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6881172b9160832687126317e4e6916b

## Summary by Sourcery

Add support for user names and password confirmation in the sign up flow

New Features:
- Extend signUp action to accept and store user name in Supabase
- Add name and confirm password fields to the SignUpForm UI
- Implement client-side check to ensure password and confirmation match before submission

Bug Fixes:
- Prevent submission and show error when passwords do not match

Enhancements:
- Rename auth credential interfaces to SignInCredentials and SignUpCredentials for clarity

Tests:
- Update SignUpForm tests to cover name input, confirm password, and mismatched password error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Name" input field and a "Confirm Password" field to the sign-up form.
  * The sign-up process now requires users to enter and confirm their password, and provide their name.

* **Bug Fixes**
  * The form now displays an error if the password and confirmation do not match, preventing submission.

* **Tests**
  * Enhanced tests to cover the new "Name" and "Confirm Password" fields, and to verify error handling for mismatched passwords.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->