### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/SmolSoftBoi/polymap/security/code-scanning/2](https://github.com/SmolSoftBoi/polymap/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root so it applies to all jobs unless overridden. The best minimal fix, without changing functionality, is:

- `contents: read`

This matches CodeQL’s recommended starting point and is sufficient for typical checkout/build/test workflows. Place it after the `on:` section (or near top-level keys) before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Build:
- Declare a top-level GitHub Actions workflow permissions block with read-only contents access for all CI jobs.